### PR TITLE
Rework MQTT autodiscovery

### DIFF
--- a/modules/cpu.py
+++ b/modules/cpu.py
@@ -3,7 +3,7 @@ import psutil
 class Addon():
     service = 'cpu'
     name = 'CPU Usage'
-    icon = 'mdi:cpu'
+    icon = 'mdi:speedometer'
     unit = '%'
 
     def getInfo(self):

--- a/modules/network.py
+++ b/modules/network.py
@@ -4,8 +4,8 @@ from datetime import datetime
 class Addon():
     service = 'network'
     name = 'Network'
-    icon = 'mdi:speedometer'
-    unit = 'Mbps'
+    icon = 'mdi:access-point-network'
+    unit = 'Mbit/s'
 
     def __init__(self):
         self.timeOld = datetime.now()


### PR DESCRIPTION
I just started using this addon and I already really like it! However, currently it is quite cumbersome to setup a new module, since a part of the autodiscovery was hardcoded in the run.py. I made a small change that uses the properties of the `Addon` to fill the autodiscovery information. This makes it also possible to create binary sensors (or other kind of sensors), which can be quite useful. 

I hope this will help more people and it can be added to the project!