### PR TITLE
Fix wrong print when setting eutomatic discovery option in config and display defaults on true/false options

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,12 +5,11 @@ import sys
 
 def query_true_false(question, default="false"):
     valid = {"true": True, "t": True, "yes": True, True: True, "false": False, "f": False, "no": False, False:False}
-    if default is None:
-        prompt = "[true/false]"
-    elif default == True:
-        prompt = "[True/false]"
-    elif default == False:
-        prompt = "[true/False]"
+
+    if default == True:
+        prompt = "(True/False) [True]"
+    elif default == False or default is None:
+        prompt = "(True/False) [False]"
     else:
         raise ValueError("invalid default answer: '%s'" % default)
 
@@ -21,7 +20,7 @@ def query_true_false(question, default="false"):
         elif choice in valid:
             return valid[choice]
         else:
-            print("Please respond with 'true' or 'false' " "(or 't' or 'f').")
+            print("Please respond with 'true' or 'false' (or 't' or 'f').")
 
 
 # config_file = 'config_temp.yaml'
@@ -44,7 +43,7 @@ with open(config_file) as f:
     print("\nLeave empty for default")
 
     # Change default values
-    y['mqtt']['discovery']['enabled'] = query_true_false("Change statsPrefix", y['mqtt']['discovery']['enabled'])
+    y['mqtt']['discovery']['enabled'] = query_true_false("Enable MQTT automatic discovery", y['mqtt']['discovery']['enabled'])
     y['mqtt']['server'] = input(f" MQTT server [{y['mqtt']['server']}]: ") or y['mqtt']['server']
     y['mqtt']['port'] = input(f" MQTT port [{y['mqtt']['port']}]: ") or y['mqtt']['port']
     y['mqtt']['auth']['user'] = input(f" MQTT username [{y['mqtt']['auth']['user']}]: ") or y['mqtt']['auth']['user']


### PR DESCRIPTION
When running the configuration script the first option reads `Change statsPrefix` but it is actually changing the mqtt.discovery.enabled option.

![image](https://user-images.githubusercontent.com/204293/163576109-a6e9a87b-3733-432f-bf15-3cd953a8f626.png)

Also the True/False options have the option to leave blank for default but it doens't say what the default is so we are forced to always write it to make sure, so I added the default option in brakets so it's coherent with the other types of options. This should make the initial configuration more friendly.


