### PR TITLE
Add fedora/redhat support on install script and add missing sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,25 +2,37 @@
 
 # Global
 basedir=/opt/lnxlink
+if [ -f /etc/debian_version ]; then
+    installcommand='apt-get --yes --force-yes install'
+    system='debian/ubuntu'
+    sudo apt-get update
+elif [ -d /etc/yum.repos.d ]; then
+    installcommand='dnf install -y'
+    system='redhat/fedora'
+else
+    echo 'Warning! System type not recognized. Trying apt package manager.'
+    installcommand='apt-get --yes --force-yes install'
+    system='debian/ubuntu'
+fi
 
 # Installing with apt-get
 echo -e "\e[35mLooking for GIT...\e[0m"
 if [ -z $(which git) ]; then
-    echo -e "\e[31mGit not found, installing from apt-get:\e[0m"
-    sudo apt-get --yes --force-yes install git
+    echo -e "\e[31mGit not found, installing from $system package manager:\e[0m"
+    sudo $installcommand git
 fi
 
 
 echo -e "\e[35mLooking for Python3...\e[0m"
 if [ -z $(which python3) ]; then
-    echo -e "\e[31mPython3 not found, installing from apt-get:\e[0m"
-    sudo apt-get --yes --force-yes install python3
+    echo -e "\e[31mPython3 not found, installing from $system package manager:\e[0m"
+    sudo $installcommand python3
 fi
 
 echo -e "\e[35mLooking for PIP3...\e[0m"
 if [ -z $(which pip3) ]; then
-    echo -e "\e[31mPIP3 not found, installing from apt-get:\e[0m"
-    sudo apt-get --yes --force-yes install python3-pip
+    echo -e "\e[31mPIP3 not found, installing from $system package manager:\e[0m"
+    sudo $installcommand python3-pip
 fi
 
 
@@ -28,7 +40,7 @@ fi
 if [ ! -d $basedir ]; then
     echo -e "\e[35mDownloading from GitHub...\e[0m"
     sudo git clone https://github.com/bkbilly/lnxlink.git $basedir
-    cp $basedir/config_temp.yaml $basedir/config.yaml
+    sudo cp $basedir/config_temp.yaml $basedir/config.yaml
 else
     echo -e "\e[35mAlready exists, updating...\e[0m"
     sudo git -C $basedir pull origin master
@@ -36,8 +48,12 @@ fi
 
 # Install Python requirements
 echo -e "\e[35mInstalling Python requirements...\e[0m"
+if [ "$system" == "redhat/fedora" ]; then
+    # python3-devel and  needed on fedora to install evdev (a dependency of pynput)
+    sudo $installcommand kernel-headers-$(uname -r) python3-devel gcc
+fi
+sudo $installcommand python3-alsaaudio
 sudo pip3 install -r $basedir/requirements.txt
-sudo apt install python3-alsaaudio
 
 # User config
 echo -e "\e[35mUser configuration setup...\e[0m"


### PR DESCRIPTION
I've added support for redhat-like sistems, I've tested it in Fedora, Centos and Ubuntu.

Also previous line 31 missed a sudo, without is the cp command failed because the clone is made as root. Causing errors like #2