### PR TITLE
✨ Improve microphone detection

### DIFF
--- a/lnxlink/modules/microphone_used.py
+++ b/lnxlink/modules/microphone_used.py
@@ -1,4 +1,6 @@
 import glob
+import subprocess
+import json
 
 
 class Addon():
@@ -8,11 +10,23 @@ class Addon():
         self.icon = 'mdi:microphone'
         self.sensor_type = 'binary_sensor'
 
+        self.use_pactl = subprocess.run(f"which pactl && pactl -f json list", shell=True).returncode == 0
+
+
     def getInfo(self):
-        mics = glob.glob('/proc/asound/**/*c/sub*/status', recursive=True)
-        for mic in mics:
-            with open(mic) as mic_content:
-                mic_status = mic_content.read().strip().lower()
-                if mic_status != 'closed':
-                    return "ON"
-        return "OFF"
+        if self.use_pactl:
+            stdout = subprocess.run(f"pactl -f json list", shell=True,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE).stdout.decode("UTF-8")
+            data = json.loads(stdout)
+            if 'source_outputs' in data and len(data['source_outputs']) > 0:
+                return 'ON'
+            return "OFF"
+        else:
+            mics = glob.glob('/proc/asound/**/*c/sub*/status', recursive=True)
+            for mic in mics:
+                with open(mic) as mic_content:
+                    mic_status = mic_content.read().strip().lower()
+                    if mic_status != 'closed':
+                        return "ON"
+            return "OFF"


### PR DESCRIPTION
When using pipewire, microphone may be seen as "used" by pipewire even though no client is consuming feed from microphone.

One solution is to use pulseaudio tooling (which pipewire is compatible with) to test for "real" clients of microphone feed.

This patch allows existing plugin to check for pactl binary as a marker of pulseaudio compatible system (pulseaudio or pipewire) and prefers to use it when possible.
We still fallback to /proc/asound virtual filesystem so this is backward compatible.

We also check for existence of the -f option wich appeared in libpulse 16.0
 We still fallback to /proc/asound virtual filesystem so this is backward compatible.
    
Reference: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/7f76edb9079f80f3f63ec70e24ef9b18e155f743