### PR TITLE
Fix gpu.py on systems without nvidia gpu (added fallback in case nvidia-smi doesn't exist)

### DIFF
--- a/lnxlink/modules/gpu.py
+++ b/lnxlink/modules/gpu.py
@@ -1,5 +1,6 @@
 import pyamdgpuinfo
 import nvsmi
+from shutil import which
 
 
 class Addon():
@@ -7,9 +8,12 @@ class Addon():
     def __init__(self, lnxlink):
         self.name = 'GPU'
         self.gpu_ids = {
-            "nvidia": len(list(nvsmi.get_gpus())),
-            "amd": pyamdgpuinfo.detect_gpus(),
+            "amd": pyamdgpuinfo.detect_gpus()
         }
+        if which("nvidia-smi") is not None:
+            self.gpu_ids["nvidia"] = len(list(nvsmi.get_gpus()))
+        else:
+            self.gpu_ids["nvidia"] = 0
 
     def getControlInfo(self):
         gpus = {}


### PR DESCRIPTION
Sometimes I feel like the only user of lnxlink with amd gpu. Anyway...

The issue is simple. `nvidia-smi` executable used by `nvsmi` is part of nvidia drivers and isn't available standalone (as stated [here](https://developer.nvidia.com/nvidia-system-management-interface)):
> **NVIDIA-smi ships with NVIDIA GPU display drivers** on Linux, and with 64bit Windows Server 2008 R2 and Windows 7. Nvidia-smi can report query information as XML or human readable plain text to either standard output or a file.

This PR adds a check for the existence of `nvidia-smi` executable with the use of [shutil.which](https://docs.python.org/3/library/shutil.html#shutil.which). Nothing more.

The whole if statement can be condensed to:
```
self.gpu_ids["nvidia"] = len(list(nvsmi.get_gpus())) if which("nvidia-smi") is not None else 0
```
but I feel like it's less readable.