### PR TITLE
Fix `/docker/btrfs` mount in `disk_usage` module 

### DIFF
--- a/lnxlink/modules/disk_usage.py
+++ b/lnxlink/modules/disk_usage.py
@@ -53,6 +53,8 @@ class Addon:
                 continue
             if "/snap/" in disk.mountpoint:
                 continue
+            if "/docker/btrfs" in disk.mountpoint:
+                continue
             device = disk.device.replace("/", "_").strip("_")
             disks[device] = {}
             disk_stats = psutil.disk_usage(disk.mountpoint)


### PR DESCRIPTION
`/var/lib/docker/btrfs` is not accessible as normal user, also the docker dir can be in different locations.

Original Exception:
`PermissionError: [Errno 13] Permission denied: '/var/lib/docker/btrfs'`