### PR TITLE
Allow including or excluding disks

### DIFF
--- a/lnxlink/consts.py
+++ b/lnxlink/consts.py
@@ -85,5 +85,8 @@ settings:
     inputs:
     outputs:
   hotkeys:
+  disk_usage:
+    include_disks: []
+    exclude_disks: []
   statistics: "https://analyzer.bkbilly.workers.dev"
 """

--- a/lnxlink/modules/disk_usage.py
+++ b/lnxlink/modules/disk_usage.py
@@ -52,8 +52,16 @@ class Addon:
     def _get_disks(self):
         """Get a list of all disks"""
         disks = {}
-        disk_includes = self.lnxlink.config["settings"].get("disk_usage", []).get("include_disks", [])
-        disk_excludes = self.lnxlink.config["settings"].get("disk_usage", []).get("exclude_disks", [])
+        disk_includes = (
+            self.lnxlink.config["settings"]
+            .get("disk_usage", [])
+            .get("include_disks", [])
+        )
+        disk_excludes = (
+            self.lnxlink.config["settings"]
+            .get("disk_usage", [])
+            .get("exclude_disks", [])
+        )
         for disk in psutil.disk_partitions():
             matches = [
                 "/snap/",

--- a/lnxlink/modules/disk_usage.py
+++ b/lnxlink/modules/disk_usage.py
@@ -52,6 +52,8 @@ class Addon:
     def _get_disks(self):
         """Get a list of all disks"""
         disks = {}
+        disk_includes = self.lnxlink.config["settings"].get("disk_usage", []).get("include_disks", [])
+        disk_excludes = self.lnxlink.config["settings"].get("disk_usage", []).get("exclude_disks", [])
         for disk in psutil.disk_partitions():
             matches = [
                 "/snap/",
@@ -62,6 +64,12 @@ class Addon:
                 continue
             if disk.fstype == "squashfs":
                 continue
+            if len(disk_includes) != 0:
+                if not any(disk.device.startswith(x) for x in disk_includes):
+                    continue
+            if len(disk_excludes) != 0:
+                if any(disk.device.startswith(x) for x in disk_excludes):
+                    continue
 
             try:
                 disk_stats = psutil.disk_usage(disk.mountpoint)


### PR DESCRIPTION
By default all discovered disks are added to Home Assistant, including any removable media.
Since all devices are added through a persisted MQTT message, they will eventually appear as "unavailable" in Home Assistant and you're not able to remove them unless you delete the persisted message using MQTT browser.

This change allows including or excluding disks. An example configuration:

```
settings:
  systemd: null
  gpio:
    inputs: null
    outputs: null
  disk_usage:
    include_disks:
      - /dev/sda
      - /dev/sdb
      - /dev/sdc
      - /dev/sdd
```


