### PR TITLE
updating microphone_used.py to ignore a dummy/blank app_name

### DIFF
--- a/lnxlink/modules/microphone_used.py
+++ b/lnxlink/modules/microphone_used.py
@@ -31,7 +31,7 @@ class Addon:
             data = json.loads(stdout)
             for output in data:
                 app_name = output.get("properties", {}).get("application.name")
-                if app_name is not None:
+                if app_name and app_name != "":
                     return {"is_used": "ON", "application": app_name}
             return {"is_used": "OFF", "application": None}
         mics = glob.glob("/proc/asound/**/*c/sub*/status", recursive=True)


### PR DESCRIPTION
Fixes bkbilly/lnxlink#133 by ignoring `application.name = ""` corresponding to dummy/phantom outputs.