### PR TITLE
make sys_updates for apt systems independent from system language

### DIFF
--- a/lnxlink/modules/sys_updates.py
+++ b/lnxlink/modules/sys_updates.py
@@ -19,7 +19,7 @@ class Addon:
         self.package_manager = None
         if which("apt") is not None:
             self.package_manager = {
-                "command": "apt list --upgradable | grep -v 'Listing...' | awk -F '/' '{print $1}'",
+                "command": "apt list --upgradable | grep -v '.*...' | awk -F '/' '{print $1}'",
                 "largerthan": 0,
             }
         elif which("yum") is not None:


### PR DESCRIPTION
Change to make the sys_updates module independent from the system language.

When a user has a system language which is not English the current command results in always having 1 update available.
Which is then "Listing..." in the users system language.

This change makes it language independent without having to force apt to run in English. Which could give errors if the requested language would not be installed on the system.