### PR TITLE
Fix incorrect regex statement for pending updates for OSs that use apt

### DIFF
--- a/lnxlink/modules/sys_updates.py
+++ b/lnxlink/modules/sys_updates.py
@@ -19,7 +19,7 @@ class Addon:
         self.package_manager = None
         if which("apt") is not None:
             self.package_manager = {
-                "command": "apt list --upgradable | grep -v '.*...' | awk -F '/' '{print $1}'",
+                "command": "apt list --upgradable | grep -v '.*\.\.\.' | awk -F '/' '{print $1}'",
                 "largerthan": 0,
             }
         elif which("yum") is not None:


### PR DESCRIPTION
Should work for all languages including right-to-left ones.

Fixes #169