### PR TITLE
Allow filtering of batteries

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -78,6 +78,10 @@ class LNXlink:
         threading.Thread(target=self.monitor_queue, daemon=True).start()
         return mqtt_status
 
+    def add_settings(self, name, settings):
+        """Adds missing configuration under settings"""
+        self.config = config_setup.add_settings(self.config, name, settings)
+
     def publish_monitor_data(self, name, pub_data):
         """Publish info data to mqtt in the correct format"""
         subtopic = helpers.text_to_topic(name)

--- a/lnxlink/consts.py
+++ b/lnxlink/consts.py
@@ -90,6 +90,9 @@ settings:
     inputs:
     outputs:
   hotkeys:
+  battery:
+    include_batteries: []
+    exclude_batteries: []
   disk_usage:
     include_disks: []
     exclude_disks: []

--- a/lnxlink/modules/battery.py
+++ b/lnxlink/modules/battery.py
@@ -59,7 +59,25 @@ class Addon:
 
     def _get_devices(self):
         devices = {}
+        battery_includes = (
+            self.lnxlink.config["settings"]
+            .get("battery", {})
+            .get("include_batteries", [])
+        )
+        battery_excludes = (
+            self.lnxlink.config["settings"]
+            .get("battery", {})
+            .get("exclude_batteries", [])
+        )
+
         for device in self.get_batteries():
+            if len(battery_includes) != 0:
+                if not any(device["Model"].startswith(x) for x in battery_includes):
+                    continue
+            if len(battery_excludes) != 0:
+                if any(device["Model"].startswith(x) for x in battery_excludes):
+                    continue
+
             native_path = device["NativePath"].split("/")[-1]
             name = (
                 " ".join(


### PR DESCRIPTION
Similar to filtering disks, this code allows the filtering of batteries based on the model name.
This could be interesting to exclude devices like Bluetooth speakers or even mouse and keyboard.

Example configuration:

```yaml
settings:
  systemd: null
  gpio:
    inputs: null
    outputs: null
  battery:
    include_batteries: []
    exclude_batteries:
      - SRS-XB43
```

One-liner to get all the device model names:
`upower -e | xargs -n1 upower -i`

The reason for picking the model name as the key for filtering is because it seems the most reliable way to do so. The native path can change if you e.g. you move a keyboard/mouse dongle from USB port and the serial is often missing or 00-00-00-00.