### PR TITLE
Small improvements to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM python:3.12-slim-bookworm
+FROM docker.io/python:3.12-slim-bookworm
 
 WORKDIR /opt/lnxlink
 
-COPY . /opt/lnxlink
-
-RUN apt update
-RUN apt install -y systemd dbus cmake gcc python3-dev xdg-utils
-RUN apt install -y xdotool x11-xserver-utils
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+	apt-get install -y systemd dbus cmake gcc python3-dev xdg-utils && \
+	apt-get install -y xdotool x11-xserver-utils && \
+	rm -rf /var/lib/apt/lists/* && \
+	apt-get clean
 
 RUN pip --no-cache-dir install docker vdf flask waitress
 RUN pip --no-cache-dir install jeepney dbus-mediaplayer dbus-notification dbus-idle
 RUN pip --no-cache-dir install ewmh python-xlib xlib-hotkeys
 RUN pip --no-cache-dir install nvsmi nvitop
+
+COPY . /opt/lnxlink
 RUN pip --no-cache-dir install -e /opt/lnxlink
 
 ENTRYPOINT ["/usr/local/bin/lnxlink", "-ie", "audio_select,bluetooth,boot_select,keep_alive,power_profile,screen_onoff,screenshot,speech_recognition,webcam,wifi"]


### PR DESCRIPTION
These are some small improvements I'd like to suggest to the Dockerfile.

1) Adding docker.io to the image to make it compatible with Docker alternatives like podman
2) Move the copy action after the installation of dependencies so previously cached layers can be re-used without the need of re-running apt and pip
3) Make the apt process a one-liner (every layer is immutable, so removing apt's cache doesn't shrink the total image size)