### PR TITLE
Use apt-check for package list if available

### DIFF
--- a/lnxlink/modules/sys_updates.py
+++ b/lnxlink/modules/sys_updates.py
@@ -1,5 +1,6 @@
 """Checks for system updates"""
 import time
+import os
 from shutil import which
 from lnxlink.modules.scripts.helpers import syscommand
 
@@ -17,7 +18,12 @@ class Addon:
             "packages": {"updates": []},
         }
         self.package_manager = None
-        if which("apt") is not None:
+        if os.path.exists("/usr/lib/update-notifier/apt-check"):
+            self.package_manager = {
+                "command": "/usr/lib/update-notifier/apt-check --package-names 2>&1",
+                "largerthan": 0,
+            }
+        elif which("apt") is not None:
             self.package_manager = {
                 "command": "apt list --upgradable | grep -v '.*\\.\\.\\.' | awk -F '/' '{print $1}'",
                 "largerthan": 0,


### PR DESCRIPTION
`apt-check` is the mechanism used to notify users of pending updates in the MOTD notice during interactive login, and as such is light-weight and installed by default in many Ubuntu systems.  It is part of `python-apt` package.
It also has the benefit of being aware of packages being held back due to phased roll-outs.

The package is not in the default path nor linked into /etc/defaults or similar, so the full path must be used.

Tested on Ubuntu 22.04 and 24.04.  Not applicable to Debian.