### PR TITLE
Fix screen-onoff module in cases when display not detected

### DIFF
--- a/lnxlink/modules/screen_onoff.py
+++ b/lnxlink/modules/screen_onoff.py
@@ -44,7 +44,13 @@ class Addon:
 
     def start_control(self, topic, data):
         """Control system"""
-        if data.lower() == "off":
-            syscommand(f"xset -display {self.lnxlink.display} dpms force off")
-        elif data.lower() == "on":
-            syscommand(f"xset -display {self.lnxlink.display} dpms force on")
+        command = data.lower()
+        if not command in {"on", "off"}:
+            logger.error("Expected `on` or `off`, received: `%s`", command)
+        if self.lnxlink.display is not None:
+            maybe_display = f"-display {self.lnxlink.display}"
+        else:
+            maybe_display = ""
+        syscommand(
+            f"xset {maybe_display} dpms force {command}"
+        )


### PR DESCRIPTION
Screen toggle fails for me because somehow `self.lnxlink.display` is set to `None`. This is already handled gracefully in [brightness module](https://github.com/bkbilly/lnxlink/blob/master/lnxlink/modules/brightness.py#L66).

Make xset send a command without `-display` argument in cases when display not detected. The same as in brightness module.

---

BTW, I cannot find a piece of code which is responsible for setting the `lnxlink.display` variable. It is initialized to None [here](https://github.com/bkbilly/lnxlink/blob/master/lnxlink/__main__.py#L39).

Thanks for a nice piece of software! I use it to automate my Ubuntu tablet displaying Home Assistant dashboard.