### PR TITLE
Battery name sanitization

### DIFF
--- a/lnxlink/modules/battery.py
+++ b/lnxlink/modules/battery.py
@@ -87,7 +87,7 @@ class Addon:
                     [
                         device["Vendor"],
                         device["Model"],
-                        device["Serial"].replace(":", ""),
+                        device["Serial"].replace(":", "").replace("/", ""),
                     ]
                 )
                 .strip()


### PR DESCRIPTION
Please, merge this into the project. Details available in #209.

What was changed:
- removed "/" from the battery name
- it caused creation of invalid topic levels in MQTT