### PR TITLE
fix: media subprocess streams to DEVNULL and STDOUT

### DIFF
--- a/lnxlink/modules/media.py
+++ b/lnxlink/modules/media.py
@@ -290,8 +290,8 @@ class Addon:
         self.process = subprocess.Popen(
             " ".join(commands),
             shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
         )
         self.process.wait()
         logger.info("Ended playing media...")


### PR DESCRIPTION
Fixes / addresses #226 

When the subprocess streams (stdout and stderr) are connected to `subprocess.PIPE`, video playback stalls out after a while, with the amount of time depending on the stream, player, etc.

stdout is switched here to subprocess.DEVNULL to discard stdout, with stderr directed to `subprocess.STDOUT`. This results in stderr from the player reaching lnxlink and being logged if/as needed, e.g. being available in journals for systemd user units, with logs prefixed by the player's process name.