### PR TITLE
sys_updates: In apt, exclude held back packages #234

### DIFF
--- a/lnxlink/modules/sys_updates.py
+++ b/lnxlink/modules/sys_updates.py
@@ -17,9 +17,9 @@ class Addon:
             "packages": {"updates": []},
         }
         self.package_manager = None
-        if which("apt") is not None:
+        if which("apt-get") is not None:
             self.package_manager = {
-                "command": "apt list --upgradable | grep -v '.*\\.\\.\\.' | awk -F '/' '{print $1}'",
+                "command": "apt-get upgrade --dry-run | grep '^Inst ' | awk '{print $2}'",
                 "largerthan": 0,
             }
         elif which("yum") is not None:


### PR DESCRIPTION
The original method used `apt list --upgradable` which included packages held back due to phasing while simulated apt-get upgrade works as non-root and lists what packages would actually install.

This should be validated by more users who may have other Ubuntu/Debian/apt-based Linux variants to make sure it is stable before merging. This was tested on Kubuntu 25.10.

This is expected to fix #234 