### PR TITLE
Add Home Assistant API MQTT transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,36 @@ To get started with LNXlink, follow these simple steps:
 
 For detailed installation instructions, please refer to the documentation page: [bkbilly.gitbook.io/lnxlink](https://bkbilly.gitbook.io/lnxlink).
 
+# Remote Home Assistant API transport
+
+By default, LNXlink connects directly to your MQTT broker. Set
+`transport: "auto"` to try the direct broker first and fall back to the Home
+Assistant API when the broker is unavailable, for example when a laptop leaves
+your home network. If your broker is only reachable from Home Assistant, set
+`transport: "homeassistant_api"` to always use the API instead:
+
+```yaml
+mqtt:
+  transport: "auto"
+  prefix: "lnxlink"
+  clientId: "DESKTOP-Linux"
+  discovery:
+    enabled: true
+    prefix: "homeassistant"
+  lwt:
+    enabled: true
+    qos: 1
+  homeassistant:
+    url: "https://example.ui.nabu.casa"
+    token_env: "HOME_ASSISTANT_TOKEN"
+    subscribe_commands: true
+```
+
+This mode calls Home Assistant's `mqtt.publish` service for outbound messages
+and uses the Home Assistant WebSocket `mqtt/subscribe` command for LNXlink
+command topics. It is useful for Nabu Casa remote access because Home Assistant
+Cloud exposes the Home Assistant API, not the raw MQTT broker port.
+
 # Benefits
  - **Cross-Platform Compatibility:** Runs on any Linux distribution, providing flexibility and wide-ranging compatibility.
  - **Enhanced System Insights:** Gain real-time insights into your Linux machine's performance by monitoring essential system metrics.

--- a/lnxlink/consts.py
+++ b/lnxlink/consts.py
@@ -34,6 +34,10 @@ WantedBy=default.target
 
 CONFIGTEMP = """
 mqtt:
+  # Use "mqtt" for a direct broker connection, "homeassistant_api" to
+  # publish/subscribe through the Home Assistant HTTP/WebSocket API, or "auto"
+  # to try direct MQTT first and fall back to the Home Assistant API.
+  transport: "mqtt"
   prefix: 'lnxlink'
   clientId: 'DESKTOP-Linux'
   server: '192.168.1.1'
@@ -52,6 +56,14 @@ mqtt:
     enabled: true
     qos: 1
   clear_on_off: true
+  homeassistant:
+    url: ""
+    token: ""
+    token_env: ""
+    token_file: ""
+    timeout: 20
+    verify_ssl: true
+    subscribe_commands: true
 update_interval: 5
 update_on_change: false
 modules:

--- a/lnxlink/mqtt.py
+++ b/lnxlink/mqtt.py
@@ -1,15 +1,47 @@
 """MQTT methods"""
 
+# pylint: disable=attribute-defined-outside-init,too-many-instance-attributes
+
+import asyncio
+from dataclasses import dataclass
+import os
 import ssl
+import threading
 import time
 import json
 import logging
 import traceback
+import aiohttp
 import paho.mqtt.client as mqtt
+import requests
 import distro
 from lnxlink.modules.scripts import helpers
 
 logger = logging.getLogger("lnxlink")
+
+
+@dataclass
+class PublishInfo:
+    """Small paho-compatible publish result for alternate transports."""
+
+    rc: int
+    mid: int
+
+
+@dataclass
+class CommandMessage:
+    """MQTT-like command message passed to the existing on_message handler."""
+
+    topic: str
+    payload: bytes
+
+
+class HomeAssistantApiClient:
+    """MQTT client shim for Home Assistant API transport."""
+
+    def subscribe(self, topic):
+        """Subscriptions are owned by the websocket bridge."""
+        logger.debug("Home Assistant websocket subscribes to %s", topic)
 
 
 class MQTT:
@@ -18,8 +50,25 @@ class MQTT:
     def __init__(self, config):
         self.config = config
         self.publish_rc_code = 0
+        self.transport = self.config["mqtt"].get("transport", "mqtt")
+        self.use_homeassistant_api = self.transport == "homeassistant_api"
+        self._disconnecting = False
+        self._ha_api_publish_mid = 0
+        self._ha_api_publish_lock = threading.Lock()
+        self._ha_api_stop = threading.Event()
+        self._ha_api_ws_thread = None
+        self._ha_api_on_message = None
+        self._on_connect_callback = None
+        self._on_message_callback = None
 
         # Setup mqtt client object
+        if self.use_homeassistant_api:
+            self.client = HomeAssistantApiClient()
+        else:
+            self.client = self._mqtt_client()
+
+    def _mqtt_client(self):
+        """Create a direct MQTT client."""
         if hasattr(mqtt, "CallbackAPIVersion"):
             self.client = mqtt.Client(
                 client_id=f"LNXlink-{self.config['mqtt']['clientId']}",
@@ -29,9 +78,13 @@ class MQTT:
             self.client = mqtt.Client(
                 client_id=f"LNXlink-{self.config['mqtt']['clientId']}"
             )
+        return self.client
 
     def publish(self, topic, payload, retain=True):
         """Publishes messages to the MQTT broker"""
+        if self.use_homeassistant_api:
+            return self.publish_homeassistant_api(topic, payload, retain)
+
         msg_info = self.client.publish(
             topic,
             payload=payload,
@@ -51,6 +104,11 @@ class MQTT:
 
     def reconnect(self):
         """Try to reconnect to broker"""
+        if self.use_homeassistant_api:
+            logger.info("Reconnecting to Home Assistant MQTT websocket")
+            self._restart_homeassistant_api_websocket()
+            return
+
         logger.info("Reconnecting to MQTT")
         self.publish_rc_code = 0
         self.client.disconnect()
@@ -60,6 +118,13 @@ class MQTT:
 
     def disconnect(self):
         """Used when exiting"""
+        self._disconnecting = True
+        if self.use_homeassistant_api:
+            self.send_lwt("OFF")
+            self._ha_api_stop.set()
+            logger.info("Disconnected from Home Assistant MQTT API.")
+            return
+
         self.client.disconnect()
         logger.info("Disconnected from MQTT.")
         self.send_lwt("OFF")
@@ -68,15 +133,33 @@ class MQTT:
         """Sends the status of lwt, ON or OFF"""
         if status == "OFF" and not self.config["mqtt"]["lwt"]["enabled"]:
             return
-        self.client.publish(
+        self.publish(
             f"{self.config['pref_topic']}/lwt",
             payload=status,
-            qos=self.config["mqtt"]["lwt"]["qos"],
             retain=True,
         )
 
     def setup_mqtt(self, on_connect, on_message):
         """Creates the mqtt object"""
+        self._on_connect_callback = on_connect
+        self._on_message_callback = on_message
+        if self.use_homeassistant_api:
+            return self.setup_homeassistant_api(on_connect, on_message)
+
+        if self.setup_direct_mqtt(on_connect, on_message):
+            return True
+
+        if self.transport == "auto":
+            logger.warning(
+                "Direct MQTT connection failed in auto transport mode; "
+                "using Home Assistant MQTT API instead"
+            )
+            return self.switch_to_homeassistant_api()
+
+        return False
+
+    def setup_direct_mqtt(self, on_connect, on_message):
+        """Connect to the configured MQTT broker directly."""
         self.client.on_connect = on_connect
         self.client.on_message = on_message
         self.client.on_disconnect = self.on_disconnect
@@ -142,6 +225,232 @@ class MQTT:
         self.client.loop_start()
         return True
 
+    def switch_to_homeassistant_api(self):
+        """Switch the active transport to Home Assistant's MQTT API."""
+        if self.use_homeassistant_api:
+            return True
+        if self._on_connect_callback is None or self._on_message_callback is None:
+            logger.error("Cannot switch to Home Assistant MQTT API before setup")
+            return False
+
+        logger.info("Switching MQTT transport to Home Assistant API")
+        self.use_homeassistant_api = True
+        self._ha_api_stop.set()
+        try:
+            self.client.loop_stop()
+        except Exception:
+            logger.debug("Could not stop direct MQTT client loop")
+        self.client = HomeAssistantApiClient()
+        self._ha_api_stop.clear()
+        return self.setup_homeassistant_api(
+            self._on_connect_callback,
+            self._on_message_callback,
+        )
+
+    def _homeassistant_api_config(self):
+        """Return Home Assistant API transport configuration."""
+        ha_config = self.config["mqtt"].get("homeassistant", {})
+        return {
+            "url": str(ha_config.get("url", "")).rstrip("/"),
+            "token": self._homeassistant_api_token(ha_config),
+            "timeout": float(ha_config.get("timeout", 20)),
+            "verify_ssl": self._config_bool(ha_config.get("verify_ssl", True)),
+            "subscribe_commands": self._config_bool(
+                ha_config.get("subscribe_commands", True)
+            ),
+        }
+
+    def _config_bool(self, value):
+        """Parse boolean config values that may come from YAML or env strings."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ["1", "true", "yes", "on"]
+        return bool(value)
+
+    def _homeassistant_api_token(self, ha_config):
+        """Read the Home Assistant long-lived access token."""
+        token = str(ha_config.get("token", ""))
+        if token:
+            return token
+
+        token_env = str(ha_config.get("token_env", ""))
+        if token_env:
+            token = os.environ.get(token_env, "")
+            if token:
+                return token
+
+        token_file = str(ha_config.get("token_file", ""))
+        if token_file:
+            try:
+                with open(os.path.expanduser(token_file), encoding="UTF-8") as file:
+                    return file.read().strip()
+            except OSError as err:
+                logger.error("Could not read Home Assistant token file: %s", err)
+
+        return ""
+
+    def setup_homeassistant_api(self, on_connect, on_message):
+        """Connect to Home Assistant API for MQTT publish and commands."""
+        ha_config = self._homeassistant_api_config()
+        if not ha_config["url"] or not ha_config["token"]:
+            logger.error(
+                "Home Assistant MQTT API transport needs mqtt.homeassistant.url "
+                "and token/token_env/token_file"
+            )
+            return False
+
+        self._ha_api_on_message = on_message
+        logger.info("Home Assistant MQTT API transport: %s", ha_config["url"])
+        on_connect(self.client, None, None, 0)
+        if ha_config["subscribe_commands"]:
+            self._start_homeassistant_api_websocket()
+        return True
+
+    def publish_homeassistant_api(self, topic, payload, retain=True):
+        """Publish MQTT through Home Assistant's mqtt.publish service."""
+        ha_config = self._homeassistant_api_config()
+        if isinstance(payload, bytes):
+            payload = payload.decode("UTF-8")
+        elif not isinstance(payload, str):
+            payload = str(payload)
+
+        try:
+            response = requests.post(
+                f"{ha_config['url']}/api/services/mqtt/publish",
+                headers={
+                    "Authorization": f"Bearer {ha_config['token']}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "topic": topic,
+                    "payload": payload,
+                    "qos": self.config["mqtt"]["lwt"]["qos"],
+                    "retain": retain,
+                },
+                timeout=ha_config["timeout"],
+                verify=ha_config["verify_ssl"],
+            )
+            response.raise_for_status()
+            rc = 0
+        except Exception as err:
+            logger.error("Home Assistant MQTT publish failed: %s", err)
+            logger.debug(traceback.format_exc())
+            rc = 1
+
+        with self._ha_api_publish_lock:
+            self._ha_api_publish_mid += 1
+            mid = self._ha_api_publish_mid
+
+        logger.debug("Message RC Code: %s, MQTT Number: %s", rc, mid)
+        self.publish_rc_code = rc
+        return PublishInfo(rc=rc, mid=mid)
+
+    def _start_homeassistant_api_websocket(self):
+        """Start the Home Assistant websocket MQTT subscription thread."""
+        if self._ha_api_ws_thread and self._ha_api_ws_thread.is_alive():
+            return
+        self._ha_api_stop.clear()
+        self._ha_api_ws_thread = threading.Thread(
+            target=self._run_homeassistant_api_websocket,
+            daemon=True,
+        )
+        self._ha_api_ws_thread.start()
+
+    def _restart_homeassistant_api_websocket(self):
+        """Restart the Home Assistant websocket MQTT subscription thread."""
+        self._ha_api_stop.set()
+        if self._ha_api_ws_thread and self._ha_api_ws_thread.is_alive():
+            self._ha_api_ws_thread.join(timeout=5)
+        self._start_homeassistant_api_websocket()
+
+    def _run_homeassistant_api_websocket(self):
+        """Run the Home Assistant websocket bridge in its own event loop."""
+        try:
+            asyncio.run(self._homeassistant_api_websocket_loop())
+        except Exception as err:
+            logger.error("Home Assistant MQTT websocket failed: %s", err)
+            logger.debug(traceback.format_exc())
+
+    async def _homeassistant_api_websocket_loop(self):
+        """Subscribe to command topics through Home Assistant websocket."""
+        ha_config = self._homeassistant_api_config()
+        command_topic = f"{self.config['pref_topic']}/commands/#"
+        while not self._ha_api_stop.is_set():
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(
+                        f"{ha_config['url']}/api/websocket",
+                        heartbeat=30,
+                        ssl=ha_config["verify_ssl"],
+                    ) as websocket:
+                        auth_required = await websocket.receive_json()
+                        if auth_required.get("type") != "auth_required":
+                            raise RuntimeError(
+                                f"Unexpected Home Assistant websocket hello: {auth_required}"
+                            )
+                        await websocket.send_json(
+                            {
+                                "type": "auth",
+                                "access_token": ha_config["token"],
+                            }
+                        )
+                        auth_result = await websocket.receive_json()
+                        if auth_result.get("type") != "auth_ok":
+                            raise RuntimeError(
+                                f"Home Assistant websocket auth failed: {auth_result}"
+                            )
+                        await websocket.send_json(
+                            {
+                                "id": 1,
+                                "type": "mqtt/subscribe",
+                                "topic": command_topic,
+                            }
+                        )
+                        subscribe_result = await websocket.receive_json()
+                        if not subscribe_result.get("success"):
+                            raise RuntimeError(
+                                "Home Assistant MQTT subscribe failed: "
+                                f"{subscribe_result}"
+                            )
+                        logger.info(
+                            "Subscribed to MQTT commands through Home Assistant API: %s",
+                            command_topic,
+                        )
+                        await self._homeassistant_api_receive_commands(websocket)
+            except Exception as err:
+                if not self._ha_api_stop.is_set():
+                    logger.error("Home Assistant MQTT websocket disconnected: %s", err)
+                    logger.debug(traceback.format_exc())
+                    await asyncio.sleep(5)
+
+    async def _homeassistant_api_receive_commands(self, websocket):
+        """Forward Home Assistant websocket MQTT events to the command handler."""
+        while not self._ha_api_stop.is_set():
+            try:
+                message = await websocket.receive(timeout=1)
+            except asyncio.TimeoutError:
+                continue
+            if message.type == aiohttp.WSMsgType.TEXT:
+                data = json.loads(message.data)
+                event = data.get("event", {})
+                topic = event.get("topic")
+                payload = event.get("payload", "")
+                if topic and self._ha_api_on_message is not None:
+                    if not isinstance(payload, str):
+                        payload = json.dumps(payload)
+                    self._ha_api_on_message(
+                        self.client,
+                        None,
+                        CommandMessage(topic=topic, payload=payload.encode("UTF-8")),
+                    )
+            elif message.type in (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.ERROR,
+            ):
+                raise RuntimeError(f"websocket closed: {message.type}")
+
     # pylint: disable=too-many-arguments
     def on_publish(self, client, userdata, mid, reason_code, properties):
         """Trying to reconnect if the reason code is not Success"""
@@ -152,9 +461,13 @@ class MQTT:
     def on_disconnect(self, *args):
         """Disconnected from MQTT broker"""
         logger.warning("Lost connection to MQTT Broker...")
+        if self.transport == "auto" and not self._disconnecting:
+            self.switch_to_homeassistant_api()
 
     def get_rcode_name(self, rcode):
         """Returns the rcode message"""
+        if self.use_homeassistant_api and rcode == 0:
+            return "Success"
         return mqtt.connack_string(rcode)
 
     # pylint: disable=too-many-locals


### PR DESCRIPTION
## Summary

Adds optional Home Assistant API-backed MQTT transports for installations where Home Assistant can reach the MQTT broker, but the Linux client may not always be able to connect to the broker directly.

In this branch LNXlink:

- keeps the existing direct MQTT transport as the default with `mqtt.transport: mqtt`
- adds `mqtt.transport: homeassistant_api` to always publish through Home Assistant's `mqtt.publish` service and subscribe through the WebSocket `mqtt/subscribe` command
- adds `mqtt.transport: auto` to try direct MQTT first and fall back to the Home Assistant API when the broker is unavailable at startup or disconnects later
- supports Home Assistant tokens inline, through an environment variable, or through a token file
- documents the Nabu Casa/Home Assistant Cloud use case, where the Home Assistant API is reachable remotely but the raw MQTT broker port is not

## Why

Home Assistant Cloud/Nabu Casa exposes the Home Assistant HTTPS/WebSocket API, not arbitrary TCP services such as a local MQTT broker. This makes it possible for a remote Linux machine to report state and receive LNXlink commands through Home Assistant without opening the broker to the internet.

The `auto` mode is meant for laptops or other Linux hosts that move between home and remote networks: direct MQTT is used while the broker is reachable, and the Home Assistant API path takes over when it is not.

## Validation

- `python3 -m compileall -q lnxlink`
- `python3 -m black lnxlink/mqtt.py lnxlink/consts.py --check`
- `python3 -m flake8 lnxlink/mqtt.py lnxlink/consts.py --max-line-length=105 -j8 --ignore=E402,W503`
- `python3 -m pylint lnxlink/mqtt.py '--generated-members=cv2.*,player.*,alsaaudio.Mixer' --disable=duplicate-code,line-too-long,too-few-public-methods,broad-exception-caught,unused-argument,import-error`
- `python3 -m pre_commit run --all-files`
- Live smoke against a Home Assistant instance using a remote `*.ui.nabu.casa` URL: publish via the new API transport arrived on the local Mosquitto broker, and a command topic published through Home Assistant was received by the new WebSocket command bridge.
- Live `auto` smoke with a reachable local broker: LNXlink stayed on direct MQTT and the published probe arrived on Mosquitto.
- Live `auto` startup fallback smoke with an intentionally unreachable broker endpoint: LNXlink switched to the Home Assistant API and the published probe arrived on Mosquitto through Home Assistant.
- Live `auto` disconnect fallback smoke: after a direct MQTT disconnect, LNXlink switched to the Home Assistant API and the next published probe arrived on Mosquitto through Home Assistant.