### PR TITLE
Ignore UPower line-power devices in battery module

### DIFF
--- a/lnxlink/modules/battery.py
+++ b/lnxlink/modules/battery.py
@@ -3,6 +3,8 @@ from xml.etree import ElementTree
 from jeepney import DBusAddress, new_method_call
 from jeepney.io.blocking import open_dbus_connection
 
+UPOWER_DEVICE_TYPE_LINE_POWER = 1
+
 
 class Addon:
     """Addon module"""
@@ -152,6 +154,7 @@ class Addon:
                     "NativePath": self.get_property(path, device_iface, "NativePath"),
                     "Percentage": self.get_property(path, device_iface, "Percentage"),
                     "Serial": self.get_property(path, device_iface, "Serial"),
+                    "Type": self.get_property(path, device_iface, "Type"),
                     "IconName": self.get_property(path, device_iface, "IconName"),
                     "IsRechargeable": self.get_property(
                         path, device_iface, "IsRechargeable"
@@ -161,6 +164,8 @@ class Addon:
                     "TimeToEmpty": self.get_property(path, device_iface, "TimeToEmpty"),
                     "TimeToFull": self.get_property(path, device_iface, "TimeToFull"),
                 }
+                if props["Type"] == UPOWER_DEVICE_TYPE_LINE_POWER:
+                    continue
                 if props["Model"] + props["NativePath"] not in ["bb", "b", ""]:
                     if isinstance(props["Percentage"], float):
                         batteries.append(props)


### PR DESCRIPTION
## Summary

Fixes the battery module so it ignores UPower `line-power` devices instead of exposing them as 0% battery sensors.

The battery module now:

- reads each UPower device's `Type` property
- skips `Type == 1` (`line-power`) devices such as AC adapters and USB-C power-source endpoints
- keeps real battery-bearing device types such as system batteries and mice

## Bug

On systems with USB-C/UCSI power-source devices, UPower exposes entries such as:

- `/org/freedesktop/UPower/devices/line_power_AC`
- `/org/freedesktop/UPower/devices/line_power_ucsi_source_psy_USBC000o001`
- `/org/freedesktop/UPower/devices/line_power_ucsi_source_psy_USBC000o002`

They have `Type == 1` (`line-power`) and `Percentage == 0.0`. The old module accepted any UPower device with a float `Percentage`, so Home Assistant discovered these power-source endpoints as battery sensors showing `0%`.

## Validation

- `python3 -m compileall -q lnxlink`
- `python3 -m black lnxlink/modules/battery.py --check`
- `python3 -m flake8 lnxlink/modules/battery.py --max-line-length=105 -j8 --ignore=E402,W503`
- `python3 -m pylint lnxlink/modules/battery.py '--generated-members=cv2.*,player.*,alsaaudio.Mixer' --disable=duplicate-code,line-too-long,too-few-public-methods,broad-exception-caught,unused-argument,import-error`
- `python3 -m pre_commit run --all-files`
- Live check on a system where UPower reports `BAT0`, `BAT1`, `hidpp_battery_0`, `AC`, and two `ucsi-source-psy-*` devices: the patched module returned only `BAT0`, `BAT1`, and the Logitech mouse battery.
