### PR TITLE
Prune stale Home Assistant discovery configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ To get started with LNXlink, follow these simple steps:
 
 For detailed installation instructions, please refer to the documentation page: [bkbilly.gitbook.io/lnxlink](https://bkbilly.gitbook.io/lnxlink).
 
+# Home Assistant discovery lifecycle
+
+LNXlink stores the Home Assistant MQTT discovery topics it publishes in
+`discovery_registry.json` next to the configuration file. Modules can opt in to
+pruning stale discovery topics when their entities are generated from removable
+resources. A stale topic is marked on the first clean discovery run where it is
+missing, and cleared on a later clean discovery run only if it is still missing.
+This keeps temporarily disconnected resources unavailable without erasing them
+immediately, while eventually removing entities for resources that are gone.
+
 # Benefits
  - **Cross-Platform Compatibility:** Runs on any Linux distribution, providing flexibility and wide-ranging compatibility.
  - **Enhanced System Insights:** Gain real-time insights into your Linux machine's performance by monitoring essential system metrics.

--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -42,6 +42,7 @@ class LNXlink:
         self.prev_publish = {}
         self.saved_publish = {}
         self.update_change_interval = 900
+        self.discovery_registry_lock = threading.Lock()
 
         # Read configuration from yaml file
         self.publ_queue = files_setup.UniqueQueue()
@@ -226,7 +227,12 @@ class LNXlink:
 
     def on_message(self, client, userdata, msg):
         """MQTT message is received with a module command to execute"""
-        topic = msg.topic.replace(f"{self.config['pref_topic']}/commands/", "")
+        command_prefix = f"{self.config['pref_topic']}/commands/"
+        if not msg.topic.startswith(command_prefix):
+            logger.debug("Ignoring MQTT message outside command prefix: %s", msg.topic)
+            return
+
+        topic = msg.topic.replace(command_prefix, "")
         message = msg.payload
         logger.info("Message received %s: %s", topic, message)
         try:
@@ -269,15 +275,97 @@ class LNXlink:
             if filter_name is not None and filter_name != service:
                 continue
             if hasattr(addon, "exposed_controls"):
-                for exp_name, options in addon.exposed_controls().items():
+                try:
+                    exposed_controls = addon.exposed_controls()
+                except Exception as err:
+                    logger.error(
+                        "Could not prepare discovery for %s: %s, %s",
+                        service,
+                        err,
+                        traceback.format_exc(),
+                    )
+                    continue
+
+                current_topics = set()
+                discovery_ok = True
+                for exp_name, options in exposed_controls.items():
                     try:
-                        self.mqtt.setup_discovery_entities(
+                        discovery_topic = self.mqtt.setup_discovery_entities(
                             addon, service, exp_name, options
                         )
+                        if discovery_topic is not None:
+                            current_topics.add(discovery_topic)
                     except Exception as err:
+                        discovery_ok = False
                         logger.error(
                             "%s: %s, %s", exp_name, err, traceback.format_exc()
                         )
+                if discovery_ok:
+                    self._sync_discovery_registry(
+                        service,
+                        current_topics,
+                        getattr(addon, "prune_stale_discovery", False),
+                    )
+
+    def _discovery_registry_path(self):
+        """Path of the locally stored Home Assistant discovery topic registry."""
+        config_dir = os.path.dirname(os.path.realpath(self.config_path))
+        return os.path.join(config_dir, "discovery_registry.json")
+
+    def _load_discovery_registry(self):
+        """Load Home Assistant discovery topics published by this instance."""
+        try:
+            with open(self._discovery_registry_path(), encoding="UTF-8") as registry:
+                data = json.load(registry)
+            if isinstance(data, dict):
+                return data
+        except FileNotFoundError:
+            pass
+        except Exception as err:
+            logger.error("Could not read discovery registry: %s", err)
+        return {}
+
+    def _save_discovery_registry(self, registry):
+        """Persist Home Assistant discovery topics published by this instance."""
+        try:
+            with open(self._discovery_registry_path(), "w", encoding="UTF-8") as file:
+                json.dump(registry, file, indent=2, sort_keys=True)
+                file.write("\n")
+        except Exception as err:
+            logger.error("Could not write discovery registry: %s", err)
+
+    def _discovery_registry_entry(self, registry, service):
+        """Read a registry entry, including the old list-only format."""
+        entry = registry.get(service, {})
+        if isinstance(entry, list):
+            return set(entry), set()
+        if isinstance(entry, dict):
+            return set(entry.get("topics", [])), set(entry.get("stale_topics", []))
+        return set(), set()
+
+    def _sync_discovery_registry(self, service, current_topics, prune_stale):
+        """Track discovery topics and clear stale configs for opt-in modules."""
+        with self.discovery_registry_lock:
+            registry = self._load_discovery_registry()
+            previous_topics, previous_stale_topics = self._discovery_registry_entry(
+                registry, service
+            )
+            missing_topics = previous_topics - current_topics
+            topics_to_clear = set()
+            topics_to_mark_stale = set()
+            if prune_stale:
+                topics_to_clear = previous_stale_topics & missing_topics
+                topics_to_mark_stale = missing_topics - topics_to_clear
+
+            for topic in sorted(topics_to_clear):
+                logger.info("Clearing stale Home Assistant discovery topic: %s", topic)
+                self.mqtt.publish(topic, payload=None, retain=True)
+
+            registry[service] = {
+                "topics": sorted(current_topics | topics_to_mark_stale),
+                "stale_topics": sorted(topics_to_mark_stale),
+            }
+            self._save_discovery_registry(registry)
 
     def restart_script(self):
         """Restarts itself"""

--- a/lnxlink/modules/disk_usage.py
+++ b/lnxlink/modules/disk_usage.py
@@ -8,6 +8,8 @@ logger = logging.getLogger("lnxlink")
 class Addon:
     """Addon module"""
 
+    prune_stale_discovery = True
+
     def __init__(self, lnxlink):
         """Setup addon"""
         self.name = "Disk Usage"

--- a/lnxlink/modules/mounts.py
+++ b/lnxlink/modules/mounts.py
@@ -8,6 +8,8 @@ logger = logging.getLogger("lnxlink")
 class Addon:
     """Addon module"""
 
+    prune_stale_discovery = True
+
     def __init__(self, lnxlink):
         """Setup addon"""
         self.name = "Mounts"

--- a/lnxlink/mqtt.py
+++ b/lnxlink/mqtt.py
@@ -302,13 +302,17 @@ class MQTT:
 
         if options["type"] not in lookup_entities:
             logger.error("Not supported: %s", options["type"])
-            return
+            return None
         if "value_template" in discovery and options["type"] in ["camera", "image"]:
             del discovery["json_attributes_topic"]
             del discovery["json_attributes_template"]
         discovery_prefix = self.config["mqtt"]["discovery"]["prefix"]
+        discovery_topic = (
+            f"{discovery_prefix}/{options['type']}/lnxlink/"
+            f"{discovery['unique_id']}/config"
+        )
         self.publish(
-            f"{discovery_prefix}/{options['type']}/lnxlink/{discovery['unique_id']}/config",
+            discovery_topic,
             payload=json.dumps(discovery),
         )
         if options["type"] == "media_player":
@@ -316,3 +320,4 @@ class MQTT:
                 "MQTT Media Player configuration name: lnxlink/%s",
                 discovery["unique_id"],
             )
+        return discovery_topic


### PR DESCRIPTION
## Summary

Adds conservative lifecycle cleanup for Home Assistant MQTT discovery topics that LNXlink created earlier but no longer exposes.

The current implementation:

- makes `setup_discovery_entities()` return the exact discovery config topic it published
- stores published discovery topics per module in `discovery_registry.json` next to the LNXlink config file
- lets modules opt in with `prune_stale_discovery = True` when their entities are generated from removable resources
- marks a missing opt-in topic as stale on the first clean discovery run where it is absent
- clears that stale retained discovery config only on a later clean discovery run if it is still absent
- leaves non-opt-in modules tracked but not pruned, so temporary device classes can keep their Home Assistant entity/history
- skips registry updates if preparing or publishing discovery for that module raises an exception, to avoid deleting entities from a partial discovery run
- ignores non-command MQTT messages in the normal command handler

This PR opts in `disk_usage` and `mounts`, where removable drives and temporary mounts can otherwise accumulate stale Home Assistant entities.

## Why

Several modules create Home Assistant entities dynamically from devices that can appear, disappear, or be filtered later. For removable storage, keeping every old flash drive or temporary mount forever is not useful. For other device classes, deleting the entity immediately when something is briefly disconnected can be worse because it loses a useful Home Assistant entity and history.

This tries to split those cases: pruning is module opt-in, and even opted-in modules get a one-clean-discovery grace run before the retained discovery config is cleared.

A concrete related example is UPower line-power devices that were previously exposed as 0% batteries. A separate bug fix can stop publishing them in future. This lifecycle PR is the more general path for future dynamic entities, without trying to infer old broker state from retained discovery payloads.

## Maintainer question

Does this shape match how you want LNXlink to manage dynamic discovery lifecycle?

The parts I am least attached to are:

- the registry filename/location (`discovery_registry.json` next to the config)
- which modules should opt in first
- whether the one-clean-discovery grace run is the right default for opted-in modules

I intentionally avoided a retained-topic wildcard bootstrap in this version. It can see old broker state, but it requires timed subscription behavior and mapping retained discovery payloads back to LNXlink modules, which feels brittle for normal startup code.

## Validation

- `python3 -m compileall -q lnxlink`
- `python3 -m black lnxlink/__main__.py lnxlink/mqtt.py lnxlink/modules/disk_usage.py lnxlink/modules/mounts.py --check`
- `python3 -m flake8 lnxlink/__main__.py lnxlink/mqtt.py lnxlink/modules/disk_usage.py lnxlink/modules/mounts.py --max-line-length=105 -j8 --ignore=E402,W503`
- `python3 -m pylint lnxlink/__main__.py lnxlink/mqtt.py lnxlink/modules/disk_usage.py lnxlink/modules/mounts.py '--generated-members=cv2.*,player.*,alsaaudio.Mixer' --disable=duplicate-code,line-too-long,too-few-public-methods,broad-exception-caught,unused-argument,import-error`
- `python3 -m pre_commit run --all-files`
- Local smoke with a temporary registry containing one current and one missing opt-in topic: first clean discovery marked the missing topic stale without clearing it; second clean discovery cleared it with an empty retained publish.
- Local smoke for a non-opt-in module: missing topics were not cleared.
- Local smoke for `setup_discovery_entities()`: verified that it returns the same Home Assistant discovery config topic it publishes.
