### PR TITLE
fix: exit nonzero when MQTT startup fails

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -465,6 +465,10 @@ def main():
         lnxlink.disconnect()
     else:
         monitor_suspend.stop()
+        logger.error(
+            "LNXlink failed to start because the MQTT transport could not connect."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,39 @@
+"""Tests for the lnxlink command-line entry point."""
+
+# pylint: disable=missing-function-docstring
+
+import sys
+import unittest
+from unittest import mock
+
+from lnxlink import __main__ as lnxlink_main
+
+
+class MainTests(unittest.TestCase):
+    """Tests for CLI startup behavior."""
+
+    def test_failed_mqtt_start_exits_nonzero(self):
+        with (
+            mock.patch.object(sys, "argv", ["lnxlink", "--ignore-systemd"]),
+            mock.patch.object(lnxlink_main.files_setup, "setup_logger"),
+            mock.patch.object(lnxlink_main.config_setup, "setup_config"),
+            mock.patch.object(
+                lnxlink_main.files_setup,
+                "read_config",
+                return_value={"config_path": "config.yaml"},
+            ),
+            mock.patch.object(lnxlink_main, "MonitorSuspend") as monitor_suspend,
+            mock.patch.object(lnxlink_main, "GracefulKiller"),
+            mock.patch.object(lnxlink_main, "LNXlink") as lnxlink_class,
+        ):
+            lnxlink_class.return_value.start.return_value = False
+
+            with self.assertRaises(SystemExit) as raised:
+                lnxlink_main.main()
+
+        self.assertEqual(raised.exception.code, 1)
+        monitor_suspend.return_value.stop.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When the configured MQTT transport cannot establish its initial broker connection, LNXlink currently returns from `main()` without an explicit non-zero exit code. That makes service managers such as systemd treat the startup as successful even though LNXlink is not running.

This change makes the command-line entry point exit with status `1` when startup fails because the MQTT transport could not connect.

## Why

In a user service with a restart policy such as `Restart=on-failure`, an early network failure can otherwise leave LNXlink stopped after boot:

```text
Error establishing connection to MQTT broker: [Errno 101] Network is unreachable
```

Because the process exits successfully, systemd does not restart it after the network becomes available.

## Testing

- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python -m py_compile lnxlink/__main__.py tests/test_main.py`
- `.venv/bin/pre-commit run --all-files`
