### PR TITLE
fix: restore nonzero exit on MQTT startup failure

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -553,6 +553,10 @@ def main():
         lnxlink.disconnect()
     else:
         monitor_suspend.stop()
+        logger.error(
+            "LNXlink failed to start because the MQTT transport could not connect."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,47 @@
+"""Tests for the LNXlink command-line entry point."""
+# pylint: disable=missing-function-docstring
+
+import sys
+import unittest
+from contextlib import ExitStack
+from unittest import mock
+
+from lnxlink import __main__ as lnxlink_main
+
+
+class MainTests(unittest.TestCase):
+    """Verify process exit behavior."""
+
+    def test_failed_mqtt_start_exits_nonzero(self):
+        with ExitStack() as stack:
+            stack.enter_context(
+                mock.patch.object(
+                    sys, "argv", ["lnxlink", "--ignore-systemd", "-c", "config.yaml"]
+                )
+            )
+            stack.enter_context(mock.patch.object(lnxlink_main, "_run_setup_wizard"))
+            stack.enter_context(
+                mock.patch.object(
+                    lnxlink_main.config_setup,
+                    "read_config",
+                    return_value={"config_path": "config.yaml"},
+                )
+            )
+            monitor_suspend = stack.enter_context(
+                mock.patch.object(lnxlink_main, "MonitorSuspend")
+            )
+            stack.enter_context(mock.patch.object(lnxlink_main, "GracefulKiller"))
+            lnxlink_class = stack.enter_context(
+                mock.patch.object(lnxlink_main, "LNXlink")
+            )
+            lnxlink_class.return_value.start.return_value = False
+
+            with self.assertRaises(SystemExit) as raised:
+                lnxlink_main.main()
+
+        self.assertEqual(raised.exception.code, 1)
+        monitor_suspend.return_value.stop.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- stop the suspend monitor and exit with status 1 when the MQTT transport cannot start
- log the startup failure clearly
- restore focused regression coverage using Python 3.8-compatible syntax

## Context

This behavior was previously merged in #246, but that merge is no longer ancestral to current `master`; the startup branch and its regression test were both lost. Current `master` therefore exits successfully again when `LNXlink.start()` returns false.

## Testing

- `/home/kom/.local/share/pipx/venvs/lnxlink/bin/python -m unittest -v tests.test_main`
- `ruff check lnxlink/__main__.py tests/test_main.py`
- `git diff --check upstream/master...HEAD`