### PR TITLE
fix: retry failed MQTT monitor publishes

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -96,6 +96,8 @@ class LNXlink:
         self.module_failures = {}
         self.addons = {}
         self.prev_publish = {}
+        self.prev_publish_transport = {}
+        self.monitor_topics = {}
         self.saved_publish = {}
         self.update_change_interval = 900
         self.discovery_registry = DiscoveryRegistry(self.config)
@@ -137,7 +139,11 @@ class LNXlink:
         loaded.sort()
         logger.info("Loaded addons: %s", ", ".join(loaded))
 
-        mqtt_status = self.mqtt.setup_mqtt(self.on_connect, self.on_message)
+        mqtt_status = self.mqtt.setup_mqtt(
+            self.on_connect,
+            self.on_message,
+            self.invalidate_publish_cache,
+        )
         threading.Thread(target=self.monitor_run, daemon=True).start()
         threading.Thread(target=self.monitor_queue, daemon=True).start()
         return mqtt_status
@@ -172,16 +178,35 @@ class LNXlink:
         update_change_time = time.time() - self.prev_publish.get("last_update", 0)
         if update_change_time > self.update_change_interval:
             self.prev_publish = {"last_update": time.time()}
+            self.prev_publish_transport = {}
         if (
             (self.config["update_on_change"] or isinstance(pub_data, bytes))
             and self.prev_publish.get(topic) == pub_data
+            and self.prev_publish_transport.get(topic) is self.mqtt.delivery_token
             and not force_publish
         ):
             return
 
-        self.prev_publish[topic] = pub_data
         self.saved_publish[subtopic.replace("/", "_")] = pub_data
-        self.mqtt.publish(topic, pub_data, retain)
+        self._publish_monitor_message(topic, pub_data, retain)
+
+    def invalidate_publish_cache(self):
+        """Force current monitor values to publish again after transport failover."""
+        self.prev_publish = {}
+        self.prev_publish_transport = {}
+
+    def _publish_monitor_message(self, topic, pub_data, retain):
+        """Publish a monitor value and cache only transport-accepted data."""
+        if retain:
+            self.monitor_topics[topic] = pub_data
+        delivery_token = self.mqtt.delivery_token
+        msg_info = self.mqtt.publish(topic, pub_data, retain)
+        if self.mqtt.publish_accepted(msg_info):
+            self.prev_publish[topic] = pub_data
+            self.prev_publish_transport[topic] = delivery_token
+        else:
+            self.prev_publish.pop(topic, None)
+            self.prev_publish_transport.pop(topic, None)
 
     def run_module(self, name, method, retain=True, force_update=False):
         """Runs the method of a module"""
@@ -321,9 +346,7 @@ class LNXlink:
                 self.mqtt.client.is_disconnecting = True
             self.mqtt.send_lwt("OFF")
             if self.config["mqtt"]["clear_on_off"]:
-                for topic, message in self.prev_publish.items():
-                    if topic == "last_update":
-                        continue
+                for topic, message in self.monitor_topics.items():
                     message = self.replace_values_with_none(message)
                     self.mqtt.publish(topic, message)
         else:

--- a/lnxlink/mqtt.py
+++ b/lnxlink/mqtt.py
@@ -402,6 +402,7 @@ class MQTT:
         self.transport = self.config["mqtt"].get("transport", "mqtt")
         self._on_connect_callback = None
         self._on_message_callback = None
+        self._on_transport_switch_callback = None
 
         if self.transport == "homeassistant_api":
             self.client = HomeAssistantApiClient(config)
@@ -414,6 +415,22 @@ class MQTT:
         msg_info = self.client.publish(topic, payload, qos=qos, retain=retain)
         self.publish_rc_code = msg_info.rc
         return msg_info
+
+    @property
+    def delivery_token(self):
+        """Identify the client responsible for the current delivery attempt."""
+        return self.client
+
+    def publish_accepted(self, msg_info):
+        """Return whether the transport accepted responsibility for delivery."""
+        if msg_info.rc == mqtt.MQTT_ERR_SUCCESS:
+            return True
+        return (
+            self.transport != "auto"
+            and isinstance(self.client, DirectMQTTClient)
+            and self.config["mqtt"]["lwt"]["qos"] > 0
+            and msg_info.rc == mqtt.MQTT_ERR_NO_CONN
+        )
 
     def reconnect(self):
         """Try to reconnect to broker"""
@@ -435,10 +452,11 @@ class MQTT:
             retain=True,
         )
 
-    def setup_mqtt(self, on_connect, on_message):
+    def setup_mqtt(self, on_connect, on_message, on_transport_switch=None):
         """Creates the mqtt object"""
         self._on_connect_callback = on_connect
         self._on_message_callback = on_message
+        self._on_transport_switch_callback = on_transport_switch
 
         if self.client.connect(
             on_connect=on_connect,
@@ -467,6 +485,8 @@ class MQTT:
 
         logger.info("Switching MQTT transport to Home Assistant API")
         self.client.disconnect()
+        if self._on_transport_switch_callback is not None:
+            self._on_transport_switch_callback()
         self.client = HomeAssistantApiClient(self.config)
         return self.client.connect(
             on_connect=self._on_connect_callback,

--- a/tests/test_publish_retry.py
+++ b/tests/test_publish_retry.py
@@ -1,0 +1,185 @@
+"""Tests for retrying monitor values after MQTT publish failures."""
+# pylint: disable=missing-function-docstring
+
+from types import SimpleNamespace
+from unittest import mock
+
+import paho.mqtt.client as mqtt
+
+from lnxlink.__main__ import LNXlink
+from lnxlink.mqtt import MQTT, DirectMQTTClient, HomeAssistantApiClient
+
+
+def _lnxlink_with_publish_result(rc):
+    lnxlink = LNXlink.__new__(LNXlink)
+    lnxlink.config = {
+        "pref_topic": "lnxlink/test-host",
+        "update_on_change": True,
+    }
+    lnxlink.prev_publish = {}
+    lnxlink.prev_publish_transport = {}
+    lnxlink.monitor_topics = {}
+    lnxlink.saved_publish = {}
+    lnxlink.update_change_interval = 900
+    lnxlink.mqtt = mock.Mock()
+    lnxlink.mqtt.publish.return_value = SimpleNamespace(rc=rc)
+    lnxlink.mqtt.publish_accepted.side_effect = lambda result: result.rc == 0
+    lnxlink.mqtt.delivery_token = object()
+    return lnxlink
+
+
+def test_failed_publish_retries_unchanged_value():
+    lnxlink = _lnxlink_with_publish_result(rc=1)
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    lnxlink.publish_monitor_data("CPU", 42)
+
+    assert lnxlink.mqtt.publish.call_count == 2
+    assert "lnxlink/test-host/monitor_controls/cpu" not in lnxlink.prev_publish
+    assert lnxlink.saved_publish["cpu"] == 42
+
+
+def test_successful_publish_deduplicates_unchanged_value():
+    lnxlink = _lnxlink_with_publish_result(rc=0)
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    lnxlink.publish_monitor_data("CPU", 42)
+
+    lnxlink.mqtt.publish.assert_called_once_with(
+        "lnxlink/test-host/monitor_controls/cpu", 42, True
+    )
+    assert lnxlink.prev_publish["lnxlink/test-host/monitor_controls/cpu"] == 42
+
+
+def test_failed_forced_publish_invalidates_previous_success():
+    lnxlink = _lnxlink_with_publish_result(rc=0)
+    topic = "lnxlink/test-host/monitor_controls/cpu"
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    lnxlink.mqtt.publish.return_value.rc = 1
+    lnxlink.publish_monitor_data("CPU", 42, force_publish=True)
+    lnxlink.publish_monitor_data("CPU", 42)
+
+    assert lnxlink.mqtt.publish.call_count == 3
+    assert topic not in lnxlink.prev_publish
+    assert lnxlink.monitor_topics[topic] == 42
+
+
+def test_clear_on_off_keeps_last_accepted_topic_after_failed_update():
+    lnxlink = _lnxlink_with_publish_result(rc=0)
+    topic = "lnxlink/test-host/monitor_controls/cpu"
+    lnxlink.config["mqtt"] = {"clear_on_off": True}
+    lnxlink.mqtt.client = object()
+    lnxlink.mqtt.send_lwt = mock.Mock()
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    lnxlink.mqtt.publish.return_value.rc = 1
+    lnxlink.publish_monitor_data("CPU", 43)
+    lnxlink.mqtt.publish.reset_mock()
+
+    lnxlink.temp_connection_callback(True)
+
+    lnxlink.mqtt.publish.assert_called_once_with(topic, None)
+
+
+def test_clear_on_off_tracks_a_failed_first_attempt():
+    lnxlink = _lnxlink_with_publish_result(rc=1)
+    topic = "lnxlink/test-host/monitor_controls/cpu"
+    lnxlink.config["mqtt"] = {"clear_on_off": True}
+    lnxlink.mqtt.client = object()
+    lnxlink.mqtt.send_lwt = mock.Mock()
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    lnxlink.mqtt.publish.reset_mock()
+
+    lnxlink.temp_connection_callback(True)
+
+    lnxlink.mqtt.publish.assert_called_once_with(topic, None)
+
+
+def test_direct_qos_publish_queued_during_disconnect_is_not_retried():
+    lnxlink = _lnxlink_with_publish_result(rc=mqtt.MQTT_ERR_NO_CONN)
+    transport = MQTT.__new__(MQTT)
+    transport.config = {"mqtt": {"lwt": {"qos": 1}}}
+    transport.transport = "mqtt"
+    transport.client = DirectMQTTClient.__new__(DirectMQTTClient)
+    lnxlink.mqtt.publish_accepted.side_effect = transport.publish_accepted
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    lnxlink.publish_monitor_data("CPU", 42)
+
+    lnxlink.mqtt.publish.assert_called_once()
+
+
+def test_auto_transport_retries_publish_queued_on_abandoned_direct_client():
+    transport = MQTT.__new__(MQTT)
+    transport.config = {"mqtt": {"lwt": {"qos": 1}}}
+    transport.transport = "auto"
+    transport.client = DirectMQTTClient.__new__(DirectMQTTClient)
+
+    assert not transport.publish_accepted(SimpleNamespace(rc=mqtt.MQTT_ERR_NO_CONN))
+
+
+def test_auto_failover_invalidates_successfully_queued_direct_publishes():
+    lnxlink = _lnxlink_with_publish_result(rc=mqtt.MQTT_ERR_SUCCESS)
+    topic = "lnxlink/test-host/monitor_controls/cpu"
+    lnxlink.publish_monitor_data("CPU", 42)
+    assert lnxlink.prev_publish[topic] == 42
+
+    transport = MQTT.__new__(MQTT)
+    transport.config = {"mqtt": {"lwt": {"qos": 1}}}
+    transport.transport = "auto"
+    transport.client = mock.create_autospec(DirectMQTTClient, instance=True)
+    transport.client.connect.return_value = True
+    assert transport.setup_mqtt(
+        mock.Mock(), mock.Mock(), lnxlink.invalidate_publish_cache
+    )
+
+    with mock.patch.object(
+        HomeAssistantApiClient, "connect", autospec=True, return_value=True
+    ):
+        assert transport.switch_to_homeassistant_api()
+
+    assert topic not in lnxlink.prev_publish
+    lnxlink.publish_monitor_data("CPU", 42)
+    assert lnxlink.mqtt.publish.call_count == 2
+
+
+def test_stale_direct_publish_cannot_restore_cache_after_failover():
+    lnxlink = _lnxlink_with_publish_result(rc=mqtt.MQTT_ERR_SUCCESS)
+    old_transport = lnxlink.mqtt.delivery_token
+    new_transport = object()
+    attempts = 0
+
+    def finish_stale_publish(*_args):
+        nonlocal attempts
+        if attempts == 0:
+            lnxlink.invalidate_publish_cache()
+            lnxlink.mqtt.delivery_token = new_transport
+        attempts += 1
+        return SimpleNamespace(rc=mqtt.MQTT_ERR_SUCCESS)
+
+    lnxlink.mqtt.publish.side_effect = finish_stale_publish
+
+    lnxlink.publish_monitor_data("CPU", 42)
+    assert (
+        lnxlink.prev_publish_transport["lnxlink/test-host/monitor_controls/cpu"]
+        is old_transport
+    )
+
+    lnxlink.publish_monitor_data("CPU", 42)
+
+    assert lnxlink.mqtt.publish.call_count == 2
+    assert (
+        lnxlink.prev_publish_transport["lnxlink/test-host/monitor_controls/cpu"]
+        is new_transport
+    )
+
+
+def test_non_retained_publish_is_not_registered_for_shutdown_cleanup():
+    lnxlink = _lnxlink_with_publish_result(rc=0)
+    topic = "lnxlink/test-host/monitor_controls/ir_remote/event"
+
+    lnxlink.publish_monitor_data("IR Remote/Event", {"code": 42}, retain=False)
+
+    assert topic not in lnxlink.monitor_topics


### PR DESCRIPTION
## Summary

Update the update-on-change delivery cache only after the MQTT transport accepts a publish. A nonzero result now invalidates any older cached value, including after a failed forced republish, so the next normal monitor pass retries it.

Local REST state remains updated independently.

## Testing

- 3 focused publish success/failure/forced-retry tests
- Ruff on source and test
- git diff --check