### PR TITLE
fix: restore Home Assistant API timeout after resume

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -328,6 +328,9 @@ class LNXlink:
                     self.mqtt.publish(topic, message)
         else:
             logger.info("Power Up detected.")
+            self.mqtt.is_disconnecting = False
+            if hasattr(self.mqtt.client, "is_disconnecting"):
+                self.mqtt.client.is_disconnecting = False
             if self.kill:
                 self.kill = False
             self.mqtt.send_lwt("ON")

--- a/tests/test_ha_resume.py
+++ b/tests/test_ha_resume.py
@@ -1,0 +1,49 @@
+"""Tests for MQTT transport state across suspend and resume."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+from types import SimpleNamespace
+from unittest import mock
+
+from lnxlink.__main__ import LNXlink
+
+
+def _lnxlink_with_client(client):
+    lnxlink = LNXlink.__new__(LNXlink)
+    lnxlink.kill = False
+    lnxlink.config = {"mqtt": {"clear_on_off": False}}
+    lnxlink.prev_publish = {}
+    lnxlink.mqtt = mock.Mock()
+    lnxlink.mqtt.client = client
+    return lnxlink
+
+
+def test_resume_restores_home_assistant_publish_timeout_state():
+    client = SimpleNamespace(is_disconnecting=False)
+    lnxlink = _lnxlink_with_client(client)
+
+    lnxlink.temp_connection_callback(True)
+    assert lnxlink.mqtt.is_disconnecting is True
+    assert client.is_disconnecting is True
+
+    lnxlink.temp_connection_callback(False)
+
+    assert lnxlink.kill is False
+    assert lnxlink.mqtt.is_disconnecting is False
+    assert client.is_disconnecting is False
+    assert lnxlink.mqtt.send_lwt.call_args_list == [mock.call("OFF"), mock.call("ON")]
+
+
+def test_resume_does_not_add_transport_state_to_direct_mqtt_client():
+    class DirectClient:
+        pass
+
+    client = DirectClient()
+    lnxlink = _lnxlink_with_client(client)
+    lnxlink.kill = True
+    lnxlink.mqtt.is_disconnecting = True
+
+    lnxlink.temp_connection_callback(False)
+
+    assert lnxlink.mqtt.is_disconnecting is False
+    assert not hasattr(client, "is_disconnecting")
+    lnxlink.mqtt.send_lwt.assert_called_once_with("ON")


### PR DESCRIPTION
## Summary

Suspend marks the Home Assistant API client as disconnecting so shutdown publishes use a short timeout. Resume now clears that state on both the wrapper and transport before publishing LWT ON, restoring the configured API timeout.

Direct MQTT clients remain unchanged.

## Testing

- 2 focused HA API and direct MQTT callback tests
- Ruff and compileall
- git diff --check