### PR TITLE
fix: retain gamepad watchers across hotplug changes

### DIFF
--- a/lnxlink/modules/gamepad.py
+++ b/lnxlink/modules/gamepad.py
@@ -16,7 +16,7 @@ class Addon:
     def __init__(self, lnxlink):
         self.name = "Gamepad"
         self.gamepads = []
-        self.running_threads = []
+        self.running_threads = {}
         self.last_used = 0
         self.timeout_used = 40
 
@@ -45,14 +45,17 @@ class Addon:
         if self.gamepads != match:
             logger.info("Gamepads found: %s", match)
             self.gamepads = match
-            for running_thread in self.running_threads:
-                running_thread.join(1)
-            self.running_threads = []
-            for event in match:
+
+            for event in set(self.running_threads) - set(match):
+                self.running_threads.pop(event)
+
+        for event in match:
+            running_thread = self.running_threads.get(event)
+            if running_thread is None or not running_thread.is_alive():
                 watch_thr = Thread(target=self.watch_input, args=(event,), daemon=True)
                 watch_thr.start()
                 logger.debug("Started for: %s", event)
-                self.running_threads.append(watch_thr)
+                self.running_threads[event] = watch_thr
 
     def watch_input(self, event):
         """Thread that watches gamepad inputs"""

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -1,0 +1,89 @@
+"""Tests for gamepad watcher lifecycle."""
+# pylint: disable=missing-function-docstring
+
+from unittest.mock import patch
+
+from lnxlink.modules import gamepad
+
+
+class FakeThread:
+    """Record watcher creation without opening input devices."""
+
+    instances = []
+
+    def __init__(self, target, args, daemon):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.alive = False
+        self.instances.append(self)
+
+    def start(self):
+        self.alive = True
+
+    def is_alive(self):
+        return self.alive
+
+
+def test_adding_gamepad_retains_existing_watcher():
+    addon = gamepad.Addon(None)
+    outputs = iter(
+        [
+            ("H: Handlers=event1 js0", "", 0),
+            ("H: Handlers=event1 js0\nH: Handlers=event2 js1", "", 0),
+        ]
+    )
+
+    FakeThread.instances = []
+    with patch.object(gamepad, "Thread", FakeThread), patch.object(
+        gamepad, "syscommand", side_effect=lambda *args, **kwargs: next(outputs)
+    ):
+        addon.watch_gamepads()
+        event1_watcher = addon.running_threads["event1"]
+        addon.watch_gamepads()
+
+    assert addon.running_threads["event1"] is event1_watcher
+    assert set(addon.running_threads) == {"event1", "event2"}
+    assert [thread.args for thread in FakeThread.instances] == [
+        ("event1",),
+        ("event2",),
+    ]
+
+
+def test_unchanged_topology_starts_no_watcher():
+    addon = gamepad.Addon(None)
+    outputs = iter(
+        [
+            ("H: Handlers=event1 js0", "", 0),
+            ("H: Handlers=event1 js0", "", 0),
+        ]
+    )
+
+    FakeThread.instances = []
+    with patch.object(gamepad, "Thread", FakeThread), patch.object(
+        gamepad, "syscommand", side_effect=lambda *args, **kwargs: next(outputs)
+    ):
+        addon.watch_gamepads()
+        addon.watch_gamepads()
+
+    assert len(FakeThread.instances) == 1
+
+
+def test_removing_gamepad_does_not_wait_for_reader():
+    addon = gamepad.Addon(None)
+    outputs = iter(
+        [
+            ("H: Handlers=event1 js0\nH: Handlers=event2 js1", "", 0),
+            ("H: Handlers=event2 js1", "", 0),
+        ]
+    )
+
+    FakeThread.instances = []
+    with patch.object(gamepad, "Thread", FakeThread), patch.object(
+        gamepad, "syscommand", side_effect=lambda *args, **kwargs: next(outputs)
+    ):
+        addon.watch_gamepads()
+        event2_watcher = addon.running_threads["event2"]
+        addon.watch_gamepads()
+
+    assert addon.running_threads == {"event2": event2_watcher}


### PR DESCRIPTION
## Summary

Track gamepad reader threads by event device. Topology changes now keep existing live readers, start only added or dead readers, and remove stale mappings without waiting on blocking device reads.

This prevents duplicate watchers and file descriptors when a controller is added beside an existing one.

## Testing

- 3 focused add/unchanged/remove topology tests
- Ruff
- git diff --check