### PR TITLE
fix: write system service units through stdin

### DIFF
--- a/lnxlink/config_setup.py
+++ b/lnxlink/config_setup.py
@@ -129,20 +129,40 @@ def setup_systemd(config_path):
         # Install on SystemD
         Path(service_location).mkdir(parents=True, exist_ok=True)
         exec_cmd = f"{shutil.which('lnxlink')} -c {config_path}"
-        service_text = systemd_service.format(exec_cmd=exec_cmd).encode()
+        service_text = systemd_service.format(exec_cmd=exec_cmd)
+        service_path = f"{service_location}/lnxlink.service"
+        command_prefix = [sudo] if sudo else []
         try:
-            with open(f"{service_location}/lnxlink.service", "wb") as config:
+            with open(service_path, "w", encoding="UTF-8") as config:
                 config.write(service_text)
         except PermissionError:
-            cmd = f'echo "{service_text}" | {sudo} tee "{service_location}/lnxlink.service"'
-            subprocess.call(cmd, shell=True)
+            subprocess.run(
+                [*command_prefix, "tee", service_path],
+                input=service_text,
+                text=True,
+                stdout=subprocess.DEVNULL,
+                check=True,
+            )
 
-        cmd = f"{sudo} chmod +x {service_location}/lnxlink.service"
-        subprocess.call(cmd, shell=True)
-        cmd = f"{sudo} systemctl {cmd_user} enable lnxlink.service"
-        subprocess.call(cmd, shell=True)
-        cmd = f"{sudo} systemctl {cmd_user} daemon-reload"
-        subprocess.call(cmd, shell=True)
+        systemctl_scope = [cmd_user] if cmd_user else []
+        subprocess.run(
+            [*command_prefix, "chmod", "+x", service_path],
+            check=True,
+        )
+        subprocess.run(
+            [*command_prefix, "systemctl", *systemctl_scope, "daemon-reload"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                *command_prefix,
+                "systemctl",
+                *systemctl_scope,
+                "enable",
+                "lnxlink.service",
+            ],
+            check=True,
+        )
 
 
 def setup_modules(config_path):

--- a/tests/test_config_setup.py
+++ b/tests/test_config_setup.py
@@ -1,0 +1,99 @@
+"""Tests for systemd service installation."""
+
+import builtins
+import subprocess
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from lnxlink import config_setup
+from lnxlink.consts import SERVICEHEADLESS, SERVICEUSER
+
+
+def test_privileged_service_write_passes_exact_text_to_sudo_tee(tmp_path):
+    """The privileged fallback must not serialize the bytes representation."""
+    service_path = tmp_path / "lnxlink.service"
+    calls = []
+
+    def deny_service_write(path, *args, **kwargs):
+        if Path(path) == service_path:
+            raise PermissionError
+        return builtins.open(path, *args, encoding="utf-8", **kwargs)
+
+    def record_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(config_setup, "_get_service_user", return_value=0)
+        )
+        stack.enter_context(
+            patch.object(config_setup, "_query_true_false", return_value=False)
+        )
+        stack.enter_context(
+            patch.object(
+                config_setup,
+                "_get_service_vars",
+                return_value=("sudo", "", SERVICEHEADLESS, str(tmp_path)),
+            )
+        )
+        stack.enter_context(
+            patch.object(config_setup.shutil, "which", return_value="/usr/bin/lnxlink")
+        )
+        stack.enter_context(
+            patch.object(
+                config_setup, "open", side_effect=deny_service_write, create=True
+            )
+        )
+        stack.enter_context(
+            patch.object(config_setup.subprocess, "run", side_effect=record_run)
+        )
+        config_setup.setup_systemd("/tmp/lnxlink.yaml")
+
+    tee_command, tee_kwargs = calls[0]
+    expected = SERVICEHEADLESS.format(exec_cmd="/usr/bin/lnxlink -c /tmp/lnxlink.yaml")
+    assert tee_command == ["sudo", "tee", str(service_path)]
+    assert tee_kwargs["input"] == expected
+    assert tee_kwargs["text"] is True
+    assert tee_kwargs["check"] is True
+    assert tee_kwargs["stdout"] is subprocess.DEVNULL
+    assert not expected.startswith("b'")
+    assert all(call_kwargs["check"] is True for _, call_kwargs in calls)
+
+
+def test_user_service_still_writes_directly(tmp_path):
+    """A writable user service must not go through sudo or tee."""
+    calls = []
+
+    def record_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(config_setup, "_get_service_user", return_value=0)
+        )
+        stack.enter_context(
+            patch.object(config_setup, "_query_true_false", return_value=True)
+        )
+        stack.enter_context(
+            patch.object(
+                config_setup,
+                "_get_service_vars",
+                return_value=("", "--user", SERVICEUSER, str(tmp_path)),
+            )
+        )
+        stack.enter_context(
+            patch.object(config_setup.shutil, "which", return_value="/usr/bin/lnxlink")
+        )
+        stack.enter_context(
+            patch.object(config_setup.subprocess, "run", side_effect=record_run)
+        )
+        config_setup.setup_systemd("/tmp/lnxlink.yaml")
+
+    expected = SERVICEUSER.format(exec_cmd="/usr/bin/lnxlink -c /tmp/lnxlink.yaml")
+    assert (tmp_path / "lnxlink.service").read_text(encoding="UTF-8") == expected
+    assert all("tee" not in command for command, _ in calls)
+    assert calls[-2][0] == ["systemctl", "--user", "daemon-reload"]
+    assert calls[-1][0] == ["systemctl", "--user", "enable", "lnxlink.service"]


### PR DESCRIPTION
## Summary

Replace the privileged shell/echo fallback with sudo tee receiving the exact unit text on stdin. Keep the unit as text, use argument-vector subprocess calls, and check chmod, daemon-reload, and enable results.

This avoids writing a Python bytes representation beginning with b instead of a valid systemd unit.

## Testing

- 2 focused direct/fallback installation tests
- exact unit text and checked argv assertions
- Ruff and git diff --check