### PR TITLE
fix: propagate updater command failures

### DIFF
--- a/lnxlink/modules/update.py
+++ b/lnxlink/modules/update.py
@@ -82,49 +82,61 @@ class Addon:
         if "_edit" in method:
             return self._update_edit(method)
         if method == "pipx":
-            syscommand("pipx upgrade lnxlink", timeout=120)
+            _, _, returncode = syscommand("pipx upgrade lnxlink", timeout=120)
         elif method == "uv":
             uv_bin = find_uv_bin() or "uv"
-            syscommand(f"{uv_bin} tool upgrade lnxlink", timeout=120)
+            _, _, returncode = syscommand(f"{uv_bin} tool upgrade lnxlink", timeout=120)
         elif method == "flatpak":
-            syscommand("flatpak update -y io.github.bkbilly.lnxlink", timeout=120)
+            _, _, returncode = syscommand(
+                "flatpak update -y io.github.bkbilly.lnxlink", timeout=120
+            )
         elif method == "aur":
             return self._update_aur()
         elif method in ("pip", "system"):
-            syscommand(f"{sys.executable} -m pip install -U lnxlink", timeout=120)
+            _, _, returncode = syscommand(
+                f"{sys.executable} -m pip install -U lnxlink", timeout=120
+            )
         else:
             logger.warning("Update not supported for install method: %s", method)
             return False
-        return True
+        return returncode == 0
 
     def _update_edit(self, method):
         """Handle update for editable installations"""
-        syscommand(f"git -c safe.directory=* -C {self.lnxlink.path} pull", timeout=15)
+        _, _, returncode = syscommand(
+            f"git -c safe.directory=* -C {self.lnxlink.path} pull", timeout=15
+        )
+        if returncode != 0:
+            return False
         if "pip" in method:
-            syscommand(
+            _, _, returncode = syscommand(
                 f"{sys.executable} -m pip install -e {self.lnxlink.path}",
                 timeout=120,
             )
         elif "uv" in method:
             uv_bin = find_uv_bin() or "uv"
-            syscommand(
+            _, _, returncode = syscommand(
                 f"{uv_bin} pip install --python {sys.executable} -e {self.lnxlink.path}",
                 timeout=120,
             )
         else:
             logger.warning("Update not supported for install method: %s", method)
             return False
-        return True
+        return returncode == 0
 
     def _update_aur(self):
         """Handle update for AUR installations"""
         _, _, yay = syscommand("which yay", ignore_errors=True)
         _, _, paru = syscommand("which paru", ignore_errors=True)
         if yay == 0:
-            syscommand("yay -Syu --noconfirm python-lnxlink", timeout=120)
+            _, _, returncode = syscommand(
+                "yay -Syu --noconfirm python-lnxlink", timeout=120
+            )
         elif paru == 0:
-            syscommand("paru -Syu --noconfirm python-lnxlink", timeout=120)
+            _, _, returncode = syscommand(
+                "paru -Syu --noconfirm python-lnxlink", timeout=120
+            )
         else:
             logger.warning("No AUR helper found (yay or paru)")
             return False
-        return True
+        return returncode == 0

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,96 @@
+"""Tests for LNXlink self-update command status."""
+# pylint: disable=missing-function-docstring,protected-access
+
+from unittest.mock import patch
+
+import pytest
+
+from lnxlink.modules import update
+
+
+class DummyLnxlink:
+    """Minimal LNXlink interface used by the update module."""
+
+    def __init__(self, method="pipx"):
+        self.version = "2026.8.0"
+        self.install_method = method
+        self.path = "/tmp/lnxlink-source"
+        self.restart_calls = 0
+        self.published = []
+
+    def restart_script(self):
+        self.restart_calls += 1
+
+    def run_module(self, name, method):
+        self.published.append((name, method))
+
+
+@pytest.mark.parametrize("method", ["pipx", "uv", "flatpak", "pip", "system"])
+@pytest.mark.parametrize("returncode, expected", [(0, True), (42, False)])
+def test_update_methods_return_command_status(method, returncode, expected):
+    """Single-command update methods must return their command status."""
+    lnxlink = DummyLnxlink(method)
+    addon = update.Addon(lnxlink)
+
+    with patch.object(update, "syscommand", return_value=("", "", returncode)):
+        assert addon._run_update() is expected
+
+
+@pytest.mark.parametrize("helper", ["yay", "paru"])
+@pytest.mark.parametrize("returncode, expected", [(0, True), (42, False)])
+def test_aur_update_returns_package_manager_status(helper, returncode, expected):
+    """AUR helper discovery success must not hide package-manager failure."""
+
+    def command_result(command, **kwargs):
+        if command == f"which {helper}":
+            return f"/usr/bin/{helper}", "", 0
+        if command.startswith(("yay ", "paru ")):
+            return "", "", returncode
+        return "", "", 1
+
+    addon = update.Addon(DummyLnxlink("aur"))
+    with patch.object(update, "syscommand", side_effect=command_result):
+        assert addon._run_update() is expected
+
+
+@pytest.mark.parametrize("method", ["pip_edit", "uv_edit"])
+def test_editable_update_stops_after_failed_git_pull(method):
+    """A failed source update must not reinstall and restart the old checkout."""
+    commands = []
+
+    def fail_pull(command, **kwargs):
+        commands.append(command)
+        return "", "", 1
+
+    addon = update.Addon(DummyLnxlink(method))
+    with patch.object(update, "syscommand", side_effect=fail_pull):
+        assert addon._run_update() is False
+
+    assert len(commands) == 1
+    assert commands[0].startswith("git ")
+
+
+@pytest.mark.parametrize("install_returncode, expected", [(0, True), (1, False)])
+def test_editable_update_returns_reinstall_status(install_returncode, expected):
+    """A successful pull is not enough when the reinstall fails."""
+    returncodes = iter([0, install_returncode])
+
+    def command_result(command, **kwargs):
+        return "", "", next(returncodes)
+
+    addon = update.Addon(DummyLnxlink("pip_edit"))
+    with patch.object(update, "syscommand", side_effect=command_result):
+        assert addon._run_update() is expected
+
+
+@pytest.mark.parametrize("succeeded, restart_calls", [(False, 0), (True, 1)])
+def test_restart_only_runs_after_successful_update(succeeded, restart_calls):
+    """The control path must not restart after a failed update."""
+    lnxlink = DummyLnxlink()
+    addon = update.Addon(lnxlink)
+
+    with patch.object(addon, "_run_update", return_value=succeeded):
+        addon.start_control([], "install")
+
+    assert lnxlink.restart_calls == restart_calls
+    assert addon.message["in_progress"] is False


### PR DESCRIPTION
## Summary

Return the actual upgrade result for pipx, uv, Flatpak, pip/system, yay, and paru installs. Editable installs stop after a failed git pull and require the reinstall to succeed. LNXlink restarts only after a successful update.

## Testing

- 20 focused success/failure tests across supported installers
- failed editable pull does not run reinstall
- failed update does not restart
- Ruff and git diff --check