### PR TITLE
fix: publish all AUR package files

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -149,7 +149,9 @@ jobs:
           cp packaging/aur/PKGBUILD /tmp/aur-repo/PKGBUILD
           cp packaging/aur/.SRCINFO /tmp/aur-repo/.SRCINFO
           cp packaging/aur/lnxlink.install /tmp/aur-repo/lnxlink.install
+          cp packaging/aur/lnxlink.service /tmp/aur-repo/lnxlink.service
+          cp packaging/aur/config.yaml.example /tmp/aur-repo/config.yaml.example
           cd /tmp/aur-repo
-          git add PKGBUILD .SRCINFO
+          git add PKGBUILD .SRCINFO lnxlink.install lnxlink.service config.yaml.example
           git diff --cached --quiet || git commit -m "Update to version ${VERSION}"
           git push

--- a/tests/test_aur_publish_workflow.py
+++ b/tests/test_aur_publish_workflow.py
@@ -1,0 +1,50 @@
+"""Tests for the AUR publication file set."""
+
+from pathlib import Path
+
+import yaml
+
+AUR_FILES = {
+    "PKGBUILD",
+    ".SRCINFO",
+    "lnxlink.install",
+    "lnxlink.service",
+    "config.yaml.example",
+}
+
+
+def test_aur_publish_copies_and_stages_every_package_file():
+    """Every maintained AUR input must reach the commit sent to the AUR."""
+    workflow_path = Path(".github/workflows/aur-publish.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="UTF-8"))
+    steps = workflow["jobs"]["publish"]["steps"]
+    publish_script = next(
+        step["run"] for step in steps if step["name"] == "Push to AUR"
+    )
+
+    for filename in AUR_FILES:
+        assert f"cp packaging/aur/{filename} /tmp/aur-repo/{filename}" in publish_script
+
+    git_add = next(
+        line.strip()
+        for line in publish_script.splitlines()
+        if line.strip().startswith("git add ")
+    )
+    assert set(git_add.split()[2:]) == AUR_FILES
+
+
+def test_hashed_static_sources_are_in_the_published_file_set():
+    """Files hashed into PKGBUILD must be copied and staged with those hashes."""
+    workflow_path = Path(".github/workflows/aur-publish.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="UTF-8"))
+    steps = workflow["jobs"]["publish"]["steps"]
+    hash_script = next(
+        step["run"]
+        for step in steps
+        if step["name"] == "Compute SHA256 for static AUR files"
+    )
+
+    hashed_files = {"lnxlink.service", "config.yaml.example"}
+    for filename in hashed_files:
+        assert f"sha256sum packaging/aur/{filename}" in hash_script
+    assert hashed_files < AUR_FILES


### PR DESCRIPTION
## Summary

Copy and stage every file consumed by the AUR package: PKGBUILD, .SRCINFO, lnxlink.install, lnxlink.service, and config.yaml.example.

Previously service/config hashes were updated without copying those files, while lnxlink.install was copied but not staged.

## Testing

- 2 structural workflow tests for copied/staged files and hashed sources
- YAML parse
- Ruff and git diff --check