### PR TITLE
fix: retain failed discovery updates

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -407,13 +407,14 @@ class LNXlink:
                         logger.error(
                             "%s: %s, %s", exp_name, err, traceback.format_exc()
                         )
-                if discovery_ok:
-                    self.discovery_registry.sync(
-                        service,
-                        current_topics,
-                        getattr(addon, "prune_stale_discovery", False),
-                        self.mqtt,
-                    )
+                self.discovery_registry.sync(
+                    service,
+                    current_topics,
+                    getattr(addon, "prune_stale_discovery", False)
+                    if discovery_ok
+                    else False,
+                    self.mqtt,
+                )
         if filter_name is None:
             self.discovery_registry.clear_excluded(self.excluded_modules, self.mqtt)
 

--- a/lnxlink/discovery_registry.py
+++ b/lnxlink/discovery_registry.py
@@ -77,6 +77,25 @@ class DiscoveryRegistry:
             return set(entry.get("topics", [])), set(entry.get("stale_topics", []))
         return set(), set()
 
+    def _clear_topic(self, topic, mqtt):
+        """Clear a retained discovery topic and report transport acceptance."""
+        try:
+            msg_info = mqtt.publish(topic, payload="", retain=True)
+        except Exception as err:
+            logger.error(
+                "Could not clear Home Assistant discovery topic %s: %s", topic, err
+            )
+            return False
+
+        if getattr(msg_info, "rc", None) != 0:
+            logger.error(
+                "Could not clear Home Assistant discovery topic %s: MQTT RC %s",
+                topic,
+                getattr(msg_info, "rc", None),
+            )
+            return False
+        return True
+
     def clear_excluded(self, excluded_modules, mqtt):
         """Clear Home Assistant discovery topics for explicitly excluded modules."""
         if not excluded_modules:
@@ -86,14 +105,28 @@ class DiscoveryRegistry:
             updated = False
             for service in sorted(excluded_modules & set(registry)):
                 topics, stale_topics = self.registry_entry(registry, service)
+                failed_topics = set()
                 for topic in sorted(topics | stale_topics):
                     logger.info(
                         "Clearing excluded module Home Assistant discovery topic: %s",
                         topic,
                     )
-                    mqtt.publish(topic, payload="", retain=True)
-                registry.pop(service, None)
-                updated = True
+                    if not self._clear_topic(topic, mqtt):
+                        failed_topics.add(topic)
+
+                if failed_topics:
+                    remaining_topics = topics & failed_topics
+                    remaining_stale_topics = stale_topics & failed_topics
+                    updated_entry = {
+                        "topics": sorted(remaining_topics),
+                        "stale_topics": sorted(remaining_stale_topics),
+                    }
+                    if registry.get(service) != updated_entry:
+                        registry[service] = updated_entry
+                        updated = True
+                else:
+                    registry.pop(service, None)
+                    updated = True
             if updated:
                 self.save(registry)
 
@@ -111,12 +144,22 @@ class DiscoveryRegistry:
                 topics_to_clear = previous_stale_topics & missing_topics
                 topics_to_mark_stale = missing_topics - topics_to_clear
 
+            failed_topics = set()
+
             for topic in sorted(topics_to_clear):
                 logger.info("Clearing stale Home Assistant discovery topic: %s", topic)
-                mqtt.publish(topic, payload="", retain=True)
+                if not self._clear_topic(topic, mqtt):
+                    failed_topics.add(topic)
+
+            if prune_stale:
+                tracked_topics = current_topics | topics_to_mark_stale | failed_topics
+                tracked_stale_topics = topics_to_mark_stale | failed_topics
+            else:
+                tracked_topics = current_topics | previous_topics
+                tracked_stale_topics = previous_stale_topics
 
             registry[service] = {
-                "topics": sorted(current_topics | topics_to_mark_stale),
-                "stale_topics": sorted(topics_to_mark_stale),
+                "topics": sorted(tracked_topics),
+                "stale_topics": sorted(tracked_stale_topics),
             }
             self.save(registry)

--- a/lnxlink/mqtt.py
+++ b/lnxlink/mqtt.py
@@ -664,10 +664,15 @@ class MQTT:
             f"{discovery_prefix}/{options['type']}/lnxlink/"
             f"{discovery['unique_id']}/config"
         )
-        self.publish(
+        msg_info = self.publish(
             discovery_topic,
             payload=json.dumps(discovery),
         )
+        if getattr(msg_info, "rc", None) != 0:
+            raise RuntimeError(
+                f"Could not publish Home Assistant discovery topic "
+                f"{discovery_topic}: MQTT RC {getattr(msg_info, 'rc', None)}"
+            )
         if options["type"] == "media_player":
             logger.info(
                 "MQTT Media Player configuration name: lnxlink/%s",

--- a/tests/test_discovery_registry.py
+++ b/tests/test_discovery_registry.py
@@ -1,0 +1,114 @@
+"""Tests for Home Assistant discovery registry accounting."""
+# pylint: disable=missing-function-docstring
+
+import unittest
+from types import SimpleNamespace
+
+from lnxlink.discovery_registry import DiscoveryRegistry
+
+
+class FakeMQTT:
+    """Return configured MQTT result codes and retain published calls."""
+
+    def __init__(self, return_codes=()):
+        self.return_codes = iter(return_codes)
+        self.calls = []
+
+    def publish(self, topic, payload, retain=True):
+        self.calls.append((topic, payload, retain))
+        return SimpleNamespace(rc=next(self.return_codes, 0))
+
+
+class DiscoveryRegistryTest(unittest.TestCase):
+    """Verify that registry state follows accepted MQTT publishes."""
+
+    def setUp(self):
+        self.registry = DiscoveryRegistry({})
+        self.registry.file_enabled = False
+
+    def test_failed_stale_clear_remains_retryable(self):
+        topic = "homeassistant/sensor/lnxlink/old/config"
+        self.registry.registry = {
+            "disk_usage": {"topics": [topic], "stale_topics": [topic]}
+        }
+
+        self.registry.sync("disk_usage", set(), True, FakeMQTT([1]))
+
+        self.assertEqual(
+            self.registry.registry["disk_usage"],
+            {"topics": [topic], "stale_topics": [topic]},
+        )
+
+        self.registry.sync("disk_usage", set(), True, FakeMQTT([0]))
+
+        self.assertEqual(
+            self.registry.registry["disk_usage"],
+            {"topics": [], "stale_topics": []},
+        )
+
+    def test_excluded_cleanup_keeps_only_failed_topics(self):
+        first = "homeassistant/sensor/lnxlink/first/config"
+        second = "homeassistant/sensor/lnxlink/second/config"
+        self.registry.registry = {
+            "battery": {
+                "topics": [first, second],
+                "stale_topics": [second],
+            }
+        }
+
+        self.registry.clear_excluded({"battery"}, FakeMQTT([0, 1]))
+
+        self.assertEqual(
+            self.registry.registry["battery"],
+            {"topics": [second], "stale_topics": [second]},
+        )
+
+        self.registry.clear_excluded({"battery"}, FakeMQTT([0]))
+
+        self.assertNotIn("battery", self.registry.registry)
+
+    def test_non_pruning_module_keeps_topics_for_later_exclusion(self):
+        first = "homeassistant/sensor/lnxlink/first/config"
+        second = "homeassistant/sensor/lnxlink/second/config"
+        mqtt = FakeMQTT()
+
+        self.registry.sync("battery", {first}, False, mqtt)
+        self.registry.sync("battery", {second}, False, mqtt)
+
+        self.assertEqual(
+            self.registry.registry["battery"],
+            {"topics": [first, second], "stale_topics": []},
+        )
+
+        self.registry.clear_excluded({"battery"}, mqtt)
+
+        self.assertEqual(
+            mqtt.calls,
+            [(first, "", True), (second, "", True)],
+        )
+        self.assertNotIn("battery", self.registry.registry)
+
+    def test_successful_pruning_keeps_one_run_grace_period(self):
+        topic = "homeassistant/sensor/lnxlink/old/config"
+        mqtt = FakeMQTT()
+
+        self.registry.sync("disk_usage", {topic}, True, mqtt)
+        self.registry.sync("disk_usage", set(), True, mqtt)
+
+        self.assertEqual(mqtt.calls, [])
+        self.assertEqual(
+            self.registry.registry["disk_usage"],
+            {"topics": [topic], "stale_topics": [topic]},
+        )
+
+        self.registry.sync("disk_usage", set(), True, mqtt)
+
+        self.assertEqual(mqtt.calls, [(topic, "", True)])
+        self.assertEqual(
+            self.registry.registry["disk_usage"],
+            {"topics": [], "stale_topics": []},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mqtt_discovery.py
+++ b/tests/test_mqtt_discovery.py
@@ -1,0 +1,76 @@
+"""Tests for publishing Home Assistant discovery configurations."""
+# pylint: disable=missing-function-docstring
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from lnxlink.__main__ import LNXlink
+from lnxlink.mqtt import MQTT
+
+
+class MQTTDiscoveryTest(unittest.TestCase):
+    """Verify that only transport-accepted discovery publishes are returned."""
+
+    def setUp(self):
+        self.mqtt = MQTT.__new__(MQTT)
+        self.mqtt.config = {
+            "mqtt": {
+                "clientId": "host",
+                "discovery": {"prefix": "homeassistant"},
+            },
+            "pref_topic": "lnxlink/host",
+            "version": "test",
+        }
+        self.addon = SimpleNamespace(name="CPU")
+
+    def test_failed_discovery_publish_raises(self):
+        self.mqtt.publish = lambda *args, **kwargs: SimpleNamespace(rc=1)
+
+        with self.assertRaisesRegex(RuntimeError, "MQTT RC 1"):
+            self.mqtt.setup_discovery_entities(
+                self.addon, "cpu", "CPU Usage", {"type": "sensor"}
+            )
+
+    def test_successful_discovery_publish_returns_topic(self):
+        self.mqtt.publish = lambda *args, **kwargs: SimpleNamespace(rc=0)
+
+        topic = self.mqtt.setup_discovery_entities(
+            self.addon, "cpu", "CPU Usage", {"type": "sensor"}
+        )
+
+        self.assertEqual(
+            topic,
+            "homeassistant/sensor/lnxlink/host_cpu_usage/config",
+        )
+
+    def test_partial_batch_registers_success_without_pruning(self):
+        lnxlink = LNXlink.__new__(LNXlink)
+        addon = SimpleNamespace(
+            prune_stale_discovery=True,
+            exposed_controls=lambda: {
+                "First": {"type": "sensor"},
+                "Second": {"type": "sensor"},
+            },
+        )
+        lnxlink.addons = {"cpu": addon}
+        lnxlink.excluded_modules = set()
+        lnxlink.mqtt = Mock()
+        lnxlink.mqtt.setup_discovery_entities.side_effect = [
+            "homeassistant/sensor/lnxlink/first/config",
+            RuntimeError("MQTT RC 1"),
+        ]
+        lnxlink.discovery_registry = Mock()
+
+        lnxlink.setup_discovery()
+
+        lnxlink.discovery_registry.sync.assert_called_once_with(
+            "cpu",
+            {"homeassistant/sensor/lnxlink/first/config"},
+            False,
+            lnxlink.mqtt,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Discovery registry state advanced even when the transport immediately rejected a publish or retained clear. That lost the retry record while stale discovery could remain in Home Assistant.

This records only transport-accepted publishes, preserves failed clears, and keeps successful topics from a partially accepted batch without pruning them on the next sync. It does not claim broker PUBACK delivery; that requires a separate asynchronous acknowledgement design.

Validation: `pytest -q tests/test_discovery_registry.py` (7 passed), Ruff, compileall, and `git diff --check`.