### PR TITLE
fix: return typed JSON from REST endpoints

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -2,6 +2,7 @@
 """Start the LNXlink service"""
 
 import argparse
+import copy
 import inspect
 import json
 import logging
@@ -163,6 +164,7 @@ class LNXlink:
         topic = f"{self.config['pref_topic']}/monitor_controls/{subtopic}"
         if pub_data is None:
             return
+        saved_data = copy.deepcopy(pub_data)
         if isinstance(pub_data, bool):
             if pub_data is True:
                 pub_data = "ON"
@@ -190,7 +192,7 @@ class LNXlink:
         ):
             return
 
-        self.saved_publish[subtopic.replace("/", "_")] = pub_data
+        self.saved_publish[subtopic.replace("/", "_")] = saved_data
         self._publish_monitor_message(topic, pub_data, retain)
 
     def invalidate_publish_cache(self):

--- a/lnxlink/modules/restful.py
+++ b/lnxlink/modules/restful.py
@@ -23,6 +23,15 @@ class Addon:
         flask_view = import_install_package("flask", ">=3.0.3", "flask.views")
         flask = import_install_package("flask", ">=3.0.3", "flask")
 
+        def json_response(payload):
+            """Return JSON with an explicit application/json content type."""
+            if isinstance(payload, bytes):
+                payload = payload.decode("UTF-8", errors="replace")
+            return flask.Response(
+                json.dumps(payload),
+                mimetype="application/json",
+            )
+
         class ModuleInfo(flask_view.views.MethodView):
             """Get information from Addon modules"""
 
@@ -34,8 +43,8 @@ class Addon:
                 """Fetch data from modules"""
                 info = self.lnxlink.saved_publish
                 if module is None:
-                    return json.dumps(list(info.keys()))
-                return str(info.get(module))
+                    return json_response(list(info.keys()))
+                return json_response(info.get(module))
 
         class ModuleControl(flask_view.views.MethodView):
             """Control Addon modules"""
@@ -50,7 +59,7 @@ class Addon:
                 for addonmodule, addon in self.lnxlink.addons.items():
                     if hasattr(addon, "start_control"):
                         modules.append(addonmodule)
-                return json.dumps(modules)
+                return json_response(modules)
 
             def post(self, module=None):
                 """Control an Addon module"""
@@ -59,7 +68,7 @@ class Addon:
                     for addonmodule, addon in self.lnxlink.addons.items():
                         if hasattr(addon, "start_control"):
                             modules.append(addonmodule)
-                    return json.dumps(modules)
+                    return json_response(modules)
 
                 topic = flask.request.form.get("topic", "")
                 topic = f"{module}/{topic}"
@@ -70,7 +79,7 @@ class Addon:
                     if hasattr(addon, "start_control"):
                         try:
                             result = addon.start_control(topic, message)
-                            return json.dumps(result)
+                            return json_response(result)
                         except Exception as err:
                             logger.error(
                                 "Couldn't run command for module %s: %s, %s",
@@ -78,9 +87,9 @@ class Addon:
                                 err,
                                 traceback.format_exc(),
                             )
-                            return f"Error: {err}"
-                    return "No control support available"
-                return "Module not found"
+                            return json_response(f"Error: {err}")
+                    return json_response("No control support available")
+                return json_response("Module not found")
 
         app = flask.Flask(__name__)
         app.add_url_rule(

--- a/tests/test_restful_json.py
+++ b/tests/test_restful_json.py
@@ -1,0 +1,204 @@
+"""Tests for RESTful JSON response types and monitor snapshots."""
+# pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
+
+import json
+import types
+
+import flask
+import flask.views as flask_views
+
+from lnxlink.__main__ import LNXlink
+from lnxlink.modules import restful
+
+
+class CaptureFlask(flask.Flask):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._captured = True
+
+
+class DummyAddon:
+    def __init__(self, value):
+        self.value = value
+
+    def start_control(self, topic, message):
+        return self.value
+
+
+class FailingAddon:
+    def start_control(self, topic, message):
+        raise RuntimeError("control failed")
+
+
+class ReadOnlyAddon:
+    pass
+
+
+class FakeLnxlink:
+    def __init__(self):
+        self.saved_publish = {
+            "interfaces": {"eth0": {"ipv4": "1.2.3.4"}},
+            "cpu": 1,
+            "image": b"YWJj",
+            "clipboard": "true",
+        }
+        self.addons = {
+            "dummy": DummyAddon({"ok": True}),
+            "failing": FailingAddon(),
+            "readonly": ReadOnlyAddon(),
+        }
+        self.config = {"settings": {"restful": {"port": 8112}}}
+
+    def add_settings(self, *_args, **_kwargs):
+        return None
+
+
+def fake_import(name, *_args, **_kwargs):
+    if name == "waitress":
+        return types.SimpleNamespace(serve=lambda *args, **kwargs: None)
+    module_name = _args[1] if len(_args) > 1 else ""
+    if module_name == "flask.views":
+        return types.SimpleNamespace(views=flask_views)
+    return flask
+
+
+def fake_publish_lnxlink():
+    """Build the minimum current publish state without starting LNXlink."""
+    lnxlink = LNXlink.__new__(LNXlink)
+    lnxlink.config = {"pref_topic": "lnxlink/host", "update_on_change": False}
+    lnxlink.prev_publish = {}
+    lnxlink.prev_publish_transport = {}
+    lnxlink.monitor_topics = {}
+    lnxlink.saved_publish = {}
+    lnxlink.update_change_interval = 900
+    lnxlink.mqtt = types.SimpleNamespace(
+        delivery_token=object(),
+        publish=lambda *_args, **_kwargs: types.SimpleNamespace(rc=0),
+        publish_accepted=lambda info: info.rc == 0,
+    )
+    return lnxlink
+
+
+def test_restful_info_returns_json_for_dict_and_scalar():
+    captured = {}
+    original_flask = flask.Flask
+    original_import = restful.import_install_package
+    original_serve = restful.Addon._serve
+
+    class TestFlask(CaptureFlask):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["app"] = self
+
+    try:
+        flask.Flask = TestFlask
+        restful.import_install_package = fake_import
+        restful.Addon._serve = lambda *_args: None
+        restful.Addon(FakeLnxlink())
+        client = captured["app"].test_client()
+
+        dict_response = client.get("/info/interfaces")
+        scalar_response = client.get("/info/cpu")
+        bytes_response = client.get("/info/image")
+        string_response = client.get("/info/clipboard")
+
+        assert dict_response.status_code == 200
+        assert dict_response.mimetype == "application/json"
+        assert json.loads(dict_response.data) == {"eth0": {"ipv4": "1.2.3.4"}}
+
+        assert scalar_response.status_code == 200
+        assert scalar_response.mimetype == "application/json"
+        assert json.loads(scalar_response.data) == 1
+
+        assert bytes_response.status_code == 200
+        assert bytes_response.mimetype == "application/json"
+        assert json.loads(bytes_response.data) == "YWJj"
+        assert json.loads(string_response.data) == "true"
+    finally:
+        flask.Flask = original_flask
+        restful.import_install_package = original_import
+        restful.Addon._serve = original_serve
+
+
+def test_restful_control_list_and_result_are_json():
+    captured = {}
+    original_flask = flask.Flask
+    original_import = restful.import_install_package
+    original_serve = restful.Addon._serve
+
+    class TestFlask(CaptureFlask):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["app"] = self
+
+    try:
+        flask.Flask = TestFlask
+        restful.import_install_package = fake_import
+        restful.Addon._serve = lambda *_args: None
+        restful.Addon(FakeLnxlink())
+        client = captured["app"].test_client()
+
+        control_list = client.get("/control")
+        control_result = client.post(
+            "/control/dummy",
+            data={"topic": "power", "message": "on"},
+        )
+
+        assert json.loads(control_list.data) == ["dummy", "failing"]
+        assert json.loads(control_result.data) == {"ok": True}
+    finally:
+        flask.Flask = original_flask
+        restful.import_install_package = original_import
+        restful.Addon._serve = original_serve
+
+
+def test_restful_control_failures_are_json():
+    captured = {}
+    original_flask = flask.Flask
+    original_import = restful.import_install_package
+    original_serve = restful.Addon._serve
+
+    class TestFlask(CaptureFlask):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["app"] = self
+
+    try:
+        flask.Flask = TestFlask
+        restful.import_install_package = fake_import
+        restful.Addon._serve = lambda *_args: None
+        restful.Addon(FakeLnxlink())
+        client = captured["app"].test_client()
+
+        responses = {
+            client.post("/control/missing"): "Module not found",
+            client.post("/control/readonly"): "No control support available",
+            client.post("/control/failing"): "Error: control failed",
+        }
+
+        for response, expected in responses.items():
+            assert response.mimetype == "application/json"
+            assert json.loads(response.data) == expected
+    finally:
+        flask.Flask = original_flask
+        restful.import_install_package = original_import
+        restful.Addon._serve = original_serve
+
+
+def test_saved_monitor_data_is_a_published_snapshot():
+    """Later module mutations must not alter the REST snapshot."""
+    lnxlink = fake_publish_lnxlink()
+    value = {"state": "before"}
+
+    lnxlink.publish_monitor_data("Mutable", value)
+    value["state"] = "after"
+
+    assert lnxlink.saved_publish["mutable"] == {"state": "before"}
+
+
+def test_saved_boolean_remains_native_json_data():
+    lnxlink = fake_publish_lnxlink()
+
+    lnxlink.publish_monitor_data("Webcam", True)
+
+    assert lnxlink.saved_publish["webcam"] is True


### PR DESCRIPTION
## Summary

- return JSON responses with the `application/json` content type
- preserve structured monitor snapshots for REST consumers
- deep-copy saved state so later module mutation cannot change the response snapshot
- retain the current MQTT delivery acceptance and retry path after rebasing

## Verification

- focused REST tests: 5 passed
- full pre-commit suite: passed
- independent current-diff review found no actionable regression

