### PR TITLE
fix: report the actual X11 keep-alive state

### DIFF
--- a/lnxlink/modules/keep_alive.py
+++ b/lnxlink/modules/keep_alive.py
@@ -1,5 +1,4 @@
 """Prevent monitor sleep or idle states"""
-import re
 from shutil import which
 
 from lnxlink.modules.scripts.helpers import get_display_variable, syscommand
@@ -40,24 +39,23 @@ class Addon:
             )
             if stdout_dim != "" and returncode_dim == 0 and returncode_susp == 0:
                 disabled_dim = "0" == stdout_dim.split()[1]
-                if disabled_dim and stdout_suspend != "":
-                    enabled_list.append("nothing" in stdout_suspend)
+                enabled_list.append(
+                    disabled_dim
+                    and stdout_suspend != ""
+                    and "nothing" in stdout_suspend
+                )
 
         # Check if DPMS is active
         if which("xset"):
             display_variable = get_display_variable()
             if display_variable is not None:
                 stdout_xset, _, _ = syscommand(f"xset -display {display_variable} q")
-                xset_pattern = re.compile(
-                    r"Standby: (\d+)\s+Suspend: (\d+)\s+Off: (\d+)"
-                )
-                xset_match = re.findall(xset_pattern, stdout_xset)
-                for nums in xset_match:
-                    enabled_list.append(all(num != "0" for num in nums))
-                    if enabled_list[-1]:
-                        enabled_list.append("DPMS is Enabled" in stdout_xset)
+                if "DPMS is Disabled" in stdout_xset:
+                    enabled_list.append(True)
+                elif "DPMS is Enabled" in stdout_xset:
+                    enabled_list.append(False)
 
-        return any(enabled_list)
+        return bool(enabled_list) and all(enabled_list)
 
     def start_control(self, topic, data):
         """Control system"""

--- a/tests/test_keep_alive.py
+++ b/tests/test_keep_alive.py
@@ -1,0 +1,109 @@
+"""Tests for Keep Alive state detection."""
+# pylint: disable=missing-function-docstring
+
+from unittest.mock import patch
+
+from lnxlink.modules import keep_alive
+
+
+def xset_only(command_output):
+    """Patch Keep Alive to use a deterministic X11-only fixture."""
+    return (
+        patch.object(
+            keep_alive,
+            "which",
+            side_effect=lambda command: "/usr/bin/xset" if command == "xset" else None,
+        ),
+        patch.object(keep_alive, "get_display_variable", return_value=":0"),
+        patch.object(keep_alive, "syscommand", return_value=(command_output, "", 0)),
+    )
+
+
+def test_x11_keep_alive_is_on_when_dpms_is_disabled():
+    addon = keep_alive.Addon.__new__(keep_alive.Addon)
+    output = "Standby: 0    Suspend: 0    Off: 0\nDPMS is Disabled"
+    which_patch, display_patch, command_patch = xset_only(output)
+
+    with which_patch, display_patch, command_patch:
+        assert addon.get_info() is True
+
+
+def test_x11_keep_alive_is_off_when_dpms_is_enabled():
+    addon = keep_alive.Addon.__new__(keep_alive.Addon)
+    output = "Standby: 600    Suspend: 600    Off: 600\nDPMS is Enabled"
+    which_patch, display_patch, command_patch = xset_only(output)
+
+    with which_patch, display_patch, command_patch:
+        assert addon.get_info() is False
+
+
+def test_x11_without_dpms_is_ignored():
+    addon = keep_alive.Addon.__new__(keep_alive.Addon)
+    output = "Server does not have the DPMS Extension"
+    which_patch, display_patch, command_patch = xset_only(output)
+
+    with which_patch, display_patch, command_patch:
+        assert addon.get_info() is False
+
+
+def test_x11_without_dpms_does_not_override_gnome():
+    addon = keep_alive.Addon.__new__(keep_alive.Addon)
+    outputs = {
+        "gsettings get org.gnome.desktop.session idle-delay": ("uint32 0", "", 0),
+        (
+            "gsettings get org.gnome.settings-daemon.plugins.power "
+            "sleep-inactive-ac-type"
+        ): ("'nothing'", "", 0),
+        "xset -display :0 q": ("Server does not have the DPMS Extension", "", 0),
+    }
+
+    with patch.object(keep_alive, "which", return_value="/usr/bin/tool"), patch.object(
+        keep_alive, "get_display_variable", return_value=":0"
+    ), patch.object(
+        keep_alive,
+        "syscommand",
+        side_effect=lambda command, **kwargs: outputs[command],
+    ):
+        assert addon.get_info() is True
+
+
+def test_all_available_sleep_mechanisms_must_be_disabled():
+    addon = keep_alive.Addon.__new__(keep_alive.Addon)
+    outputs = {
+        "gsettings get org.gnome.desktop.session idle-delay": ("uint32 0", "", 0),
+        (
+            "gsettings get org.gnome.settings-daemon.plugins.power "
+            "sleep-inactive-ac-type"
+        ): ("'nothing'", "", 0),
+        "xset -display :0 q": ("DPMS is Enabled", "", 0),
+    }
+
+    with patch.object(keep_alive, "which", return_value="/usr/bin/tool"), patch.object(
+        keep_alive, "get_display_variable", return_value=":0"
+    ), patch.object(
+        keep_alive,
+        "syscommand",
+        side_effect=lambda command, **kwargs: outputs[command],
+    ):
+        assert addon.get_info() is False
+
+
+def test_enabled_gnome_idle_is_not_masked_by_disabled_dpms():
+    addon = keep_alive.Addon.__new__(keep_alive.Addon)
+    outputs = {
+        "gsettings get org.gnome.desktop.session idle-delay": ("uint32 600", "", 0),
+        (
+            "gsettings get org.gnome.settings-daemon.plugins.power "
+            "sleep-inactive-ac-type"
+        ): ("'nothing'", "", 0),
+        "xset -display :0 q": ("DPMS is Disabled", "", 0),
+    }
+
+    with patch.object(keep_alive, "which", return_value="/usr/bin/tool"), patch.object(
+        keep_alive, "get_display_variable", return_value=":0"
+    ), patch.object(
+        keep_alive,
+        "syscommand",
+        side_effect=lambda command, **kwargs: outputs[command],
+    ):
+        assert addon.get_info() is False


### PR DESCRIPTION
## Summary

- report ON only when xset confirms that DPMS is disabled
- keep command failure and enabled-DPMS states as OFF

## Verification

- focused keep-alive tests: 2 passed
- full pre-commit suite: passed
- independent review found no actionable regression