### PR TITLE
fix: clear gamepad activity on disconnect

### DIFF
--- a/lnxlink/modules/gamepad.py
+++ b/lnxlink/modules/gamepad.py
@@ -3,7 +3,7 @@ import logging
 import re
 import struct
 import time
-from threading import Thread
+from threading import Lock, Thread
 
 from lnxlink.modules.scripts.helpers import syscommand
 
@@ -17,7 +17,9 @@ class Addon:
         self.name = "Gamepad"
         self.gamepads = []
         self.running_threads = {}
-        self.last_used = 0
+        self.last_used = {}
+        self.watcher_tokens = {}
+        self.activity_lock = Lock()
         self.timeout_used = 40
 
     def exposed_controls(self):
@@ -32,9 +34,10 @@ class Addon:
     def get_info(self):
         """Gather information from the system"""
         self.watch_gamepads()
-        if int(time.time()) - self.last_used < self.timeout_used:
-            return True
-        return False
+        now = int(time.time())
+        with self.activity_lock:
+            last_used = list(self.last_used.values())
+        return any(now - used < self.timeout_used for used in last_used)
 
     def watch_gamepads(self):
         """Watch for gamepad connections"""
@@ -48,16 +51,26 @@ class Addon:
 
             for event in set(self.running_threads) - set(match):
                 self.running_threads.pop(event)
+                with self.activity_lock:
+                    self.watcher_tokens.pop(event, None)
+                    self.last_used.pop(event, None)
 
         for event in match:
             running_thread = self.running_threads.get(event)
             if running_thread is None or not running_thread.is_alive():
-                watch_thr = Thread(target=self.watch_input, args=(event,), daemon=True)
+                watcher_token = object()
+                with self.activity_lock:
+                    self.watcher_tokens[event] = watcher_token
+                watch_thr = Thread(
+                    target=self.watch_input,
+                    args=(event, watcher_token),
+                    daemon=True,
+                )
                 watch_thr.start()
                 logger.debug("Started for: %s", event)
                 self.running_threads[event] = watch_thr
 
-    def watch_input(self, event):
+    def watch_input(self, event, watcher_token):
         """Thread that watches gamepad inputs"""
         decode_str = "llHHI"
         try:
@@ -65,7 +78,9 @@ class Addon:
                 while game_data := file.read(struct.calcsize(decode_str)):
                     _, _, ev_type, code, value = struct.unpack(decode_str, game_data)
                     if ev_type != 0 or code != 0 or value != 0:
-                        self.last_used = int(time.time())
+                        with self.activity_lock:
+                            if self.watcher_tokens.get(event) is watcher_token:
+                                self.last_used[event] = int(time.time())
                         logger.debug("%s %s", code, value)
         except OSError as err:
             # Errno 19: "No such device" happens when the gamepad is disconnected
@@ -75,3 +90,8 @@ class Addon:
                 logger.error("Gamepad error for %s: %s", event, err)
         except Exception as err:
             logger.error("Unexpected error for %s: %s", event, err)
+        finally:
+            with self.activity_lock:
+                if self.watcher_tokens.get(event) is watcher_token:
+                    self.watcher_tokens.pop(event, None)
+                    self.last_used.pop(event, None)

--- a/tests/test_gamepad_disconnect.py
+++ b/tests/test_gamepad_disconnect.py
@@ -1,0 +1,93 @@
+"""Regression tests for gamepad activity on disconnect."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import errno
+import struct
+from unittest.mock import Mock, patch
+
+from lnxlink.modules.gamepad import Addon
+
+
+class DisconnectingInput:
+    """Return one input event, then emulate a disconnected evdev device."""
+
+    def __init__(self):
+        self.reads = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _size):
+        self.reads += 1
+        if self.reads == 1:
+            return struct.pack("llHHI", 0, 0, 1, 1, 1)
+        raise OSError(errno.ENODEV, "No such device")
+
+
+class SingleEventInput:
+    def __init__(self):
+        self.reads = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _size):
+        self.reads += 1
+        if self.reads == 1:
+            return struct.pack("llHHI", 0, 0, 1, 1, 1)
+        return b""
+
+
+def test_disconnect_clears_recent_activity():
+    gamepad = Addon(None)
+    watcher_token = object()
+    gamepad.watcher_tokens["event4"] = watcher_token
+
+    with patch("builtins.open", return_value=DisconnectingInput()):
+        gamepad.watch_input("event4", watcher_token)
+
+    assert not gamepad.last_used
+    with patch.object(gamepad, "watch_gamepads"):
+        assert gamepad.get_info() is False
+
+
+def test_removed_gamepad_does_not_clear_other_activity():
+    gamepad = Addon(None)
+    gamepad.gamepads = ["event4", "event5"]
+    gamepad.running_threads = {
+        "event4": Mock(is_alive=lambda: True),
+        "event5": Mock(is_alive=lambda: True),
+    }
+    gamepad.last_used = {"event4": 100, "event5": 200}
+
+    with patch(
+        "lnxlink.modules.gamepad.syscommand",
+        return_value=("H: Handlers=event5 js1", "", 0),
+    ):
+        gamepad.watch_gamepads()
+
+    assert gamepad.last_used == {"event5": 200}
+    with patch.object(gamepad, "watch_gamepads"):
+        with patch("lnxlink.modules.gamepad.time.time", return_value=210):
+            assert gamepad.get_info() is True
+
+
+def test_old_watcher_does_not_clear_replacement_activity():
+    gamepad = Addon(None)
+    old_token = object()
+    replacement_token = object()
+    gamepad.watcher_tokens["event4"] = replacement_token
+    gamepad.last_used["event4"] = 200
+
+    with patch("builtins.open", return_value=SingleEventInput()):
+        with patch("lnxlink.modules.gamepad.time.time", return_value=500):
+            gamepad.watch_input("event4", old_token)
+
+    assert gamepad.watcher_tokens["event4"] is replacement_token
+    assert gamepad.last_used == {"event4": 200}


### PR DESCRIPTION
## Summary

- make `Gamepad Used` return to off when an active controller disconnects
- track recent activity per input device instead of one shared timestamp
- clear only the disconnected device, preserving recent activity from other
  connected controllers

This addresses the behavior reported after
[bkbilly/lnxlink#271](https://github.com/bkbilly/lnxlink/pull/271#issuecomment-5430486014).
The reader clears activity on both device errors and clean EOF; the periodic
device scan also clears state when an input disappears from `/proc`.

## Validation

- Python 3.8 focused regression suite: 3 passed
- `uvx pre-commit run --all-files`
- independent current-diff review: no actionable findings
