### PR TITLE
Fix Media Player state after MQTT reconnect

### DIFF
--- a/lnxlink/__main__.py
+++ b/lnxlink/__main__.py
@@ -197,6 +197,9 @@ class LNXlink:
         """Force current monitor values to publish again after transport failover."""
         self.prev_publish = {}
         self.prev_publish_transport = {}
+        media_addon = getattr(self, "addons", {}).get("media")
+        if media_addon is not None and hasattr(media_addon, "invalidate_cache"):
+            media_addon.invalidate_cache()
 
     def _publish_monitor_message(self, topic, pub_data, retain):
         """Publish a monitor value and cache only transport-accepted data."""
@@ -303,6 +306,7 @@ class LNXlink:
         """Callback for MQTT connect which reports the connection status
         back to MQTT server"""
         logger.info("MQTT connection: %s", self.mqtt.get_rcode_name(rcode))
+        self.invalidate_publish_cache()
         client.subscribe(f"{self.config['pref_topic']}/commands/#")
         self.mqtt.send_lwt("ON")
         if self.config["mqtt"]["discovery"]["enabled"]:
@@ -354,6 +358,7 @@ class LNXlink:
                     self.mqtt.publish(topic, message)
         else:
             logger.info("Power Up detected.")
+            self.invalidate_publish_cache()
             self.mqtt.is_disconnecting = False
             if hasattr(self.mqtt.client, "is_disconnecting"):
                 self.mqtt.client.is_disconnecting = False

--- a/lnxlink/modules/media.py
+++ b/lnxlink/modules/media.py
@@ -218,6 +218,10 @@ class Addon:
                 self.lnxlink.run_module(f"{self.name}/albumart", "")
         return info
 
+    def invalidate_cache(self):
+        """Force media state to be queued again after reconnecting."""
+        self.prev_info = {}
+
     def media_callback(self, players):
         """Callback function to update media information"""
         self.players = players

--- a/tests/test_media_reconnect.py
+++ b/tests/test_media_reconnect.py
@@ -1,0 +1,84 @@
+"""Tests for republishing MQTT media-player state after connection loss."""
+# pylint: disable=missing-function-docstring
+
+from types import SimpleNamespace
+from unittest import mock
+
+from lnxlink.__main__ import LNXlink
+from lnxlink.modules.media import Addon
+
+
+def _media_addon():
+    lnxlink = SimpleNamespace(run_module=mock.Mock())
+    addon = Addon.__new__(Addon)
+    addon.name = "Media Info"
+    addon.lnxlink = lnxlink
+    addon.playmedia_thread = None
+    addon.process = None
+    addon.players = []
+    addon.prev_info = {}
+    addon.audio_system = None
+    addon.mediavolume = "OFF"
+    return addon, lnxlink
+
+
+def test_unchanged_media_state_is_queued_once_until_cache_invalidation():
+    addon, lnxlink = _media_addon()
+
+    addon.get_info()
+    addon.get_info()
+    addon.invalidate_cache()
+    addon.get_info()
+
+    state_calls = [
+        call
+        for call in lnxlink.run_module.call_args_list
+        if call.args[0] == "Media Info/state"
+    ]
+    assert state_calls == [
+        mock.call("Media Info/state", "off"),
+        mock.call("Media Info/state", "off"),
+    ]
+
+
+def _lnxlink_with_cached_state():
+    lnxlink = LNXlink.__new__(LNXlink)
+    lnxlink.prev_publish = {"lnxlink/test/monitor_controls/media_info/state": "off"}
+    lnxlink.prev_publish_transport = {
+        "lnxlink/test/monitor_controls/media_info/state": object()
+    }
+    addon = mock.Mock()
+    lnxlink.addons = {"media": addon}
+    lnxlink.kill = True
+    lnxlink.mqtt = mock.Mock()
+    lnxlink.mqtt.get_rcode_name.return_value = "Success"
+    return lnxlink
+
+
+def test_mqtt_reconnect_makes_unchanged_state_publishable_again():
+    lnxlink = _lnxlink_with_cached_state()
+    lnxlink.config = {
+        "pref_topic": "lnxlink/test",
+        "mqtt": {"discovery": {"enabled": False}},
+    }
+    client = mock.Mock()
+
+    lnxlink.on_connect(client, None, None, 0)
+
+    assert not lnxlink.prev_publish
+    assert not lnxlink.prev_publish_transport
+    lnxlink.addons["media"].invalidate_cache.assert_called_once_with()
+    assert lnxlink.kill is False
+
+
+def test_resume_makes_unchanged_state_publishable_again():
+    lnxlink = _lnxlink_with_cached_state()
+    lnxlink.config = {"mqtt": {"clear_on_off": False}}
+    lnxlink.mqtt.client = object()
+
+    lnxlink.temp_connection_callback(False)
+
+    assert not lnxlink.prev_publish
+    assert not lnxlink.prev_publish_transport
+    lnxlink.addons["media"].invalidate_cache.assert_called_once_with()
+    assert lnxlink.kill is False


### PR DESCRIPTION
Closes bkbilly/lnxlink#285.

The MQTT Media Player could remain `unknown` after a broker reconnect or system resume because the media module kept its own last-value cache. The core publish cache was reset after some transport failures, but the unchanged media value never reached it again.

This change invalidates both caches on MQTT reconnect and resume. Normal media change filtering remains intact, so unchanged values are republished once after recovery without adding recurring MQTT traffic.

Validation:

- `pytest -q` — 22 passed
- `pre-commit run --all-files` — all 7 hooks passed
