### PR TITLE
feat(custom_sensors): add user-defined command sensors with HA discovery

### DIFF
--- a/lnxlink/modules/custom_sensors.py
+++ b/lnxlink/modules/custom_sensors.py
@@ -1,0 +1,165 @@
+"""Create user-defined custom sensors with arbitrary commands and HA discovery metadata"""
+import json
+import logging
+import time
+from typing import Any, Dict
+
+from lnxlink.modules.scripts.helpers import syscommand
+
+logger = logging.getLogger("lnxlink")
+
+
+class Addon:
+    """Addon module for user-defined custom command sensors"""
+
+    def __init__(self, lnxlink):
+        """Setup addon"""
+        self.name = "Custom Sensors"
+        self.lnxlink = lnxlink
+        self.discovery_info: Dict[str, Dict[str, Any]] = {}
+        self.lnxlink.add_settings(
+            "custom_sensors",
+            {},
+        )
+        self.sensor_state: Dict[str, Dict[str, Any]] = {}
+
+    def _get_sensor_configs(self) -> Dict[str, Dict[str, Any]]:
+        """Normalize sensor configurations from settings dict or list"""
+        raw_settings = self.lnxlink.config["settings"].get("custom_sensors", {})
+        if raw_settings is None:
+            return {}
+
+        configs = {}
+        if isinstance(raw_settings, dict):
+            for sensor_id, cfg in raw_settings.items():
+                if isinstance(cfg, dict):
+                    configs[str(sensor_id)] = {
+                        "id": str(sensor_id),
+                        "name": cfg.get("name", str(sensor_id)),
+                        "command": cfg.get("command", ""),
+                        "type": cfg.get("type", "sensor"),
+                        "device_class": cfg.get("device_class"),
+                        "state_class": cfg.get("state_class"),
+                        "unit": cfg.get("unit") or cfg.get("unit_of_measurement"),
+                        "icon": cfg.get("icon", "mdi:gauge"),
+                        "interval": int(cfg.get("interval", cfg.get("every_sec", 10))),
+                        "timeout": int(cfg.get("timeout", 5)),
+                    }
+        elif isinstance(raw_settings, list):
+            for item in raw_settings:
+                if isinstance(item, dict):
+                    sensor_id = item.get("id") or item.get("name", "sensor")
+                    configs[str(sensor_id)] = {
+                        "id": str(sensor_id),
+                        "name": item.get("name", str(sensor_id)),
+                        "command": item.get("command", ""),
+                        "type": item.get("type", "sensor"),
+                        "device_class": item.get("device_class"),
+                        "state_class": item.get("state_class"),
+                        "unit": item.get("unit") or item.get("unit_of_measurement"),
+                        "icon": item.get("icon", "mdi:gauge"),
+                        "interval": int(item.get("interval", item.get("every_sec", 10))),
+                        "timeout": int(item.get("timeout", 5)),
+                    }
+        return configs
+
+    def exposed_controls(self) -> Dict[str, Dict[str, Any]]:
+        """Exposes to Home Assistant discovery"""
+        self.discovery_info = {}
+        configs = self._get_sensor_configs()
+
+        for sensor_id, cfg in configs.items():
+            if not cfg["command"]:
+                continue
+
+            entity_title = cfg["name"]
+            control_type = cfg["type"]
+            control_def: Dict[str, Any] = {
+                "type": control_type,
+                "icon": cfg["icon"],
+                "subtopic": True,
+                "value_template": "{{ value_json.value if (value_json is mapping and 'value' in value_json) else value }}",
+                "attributes_template": "{{ value_json.attributes | tojson if (value_json is mapping and 'attributes' in value_json) else '{}' }}",
+            }
+            if cfg.get("unit"):
+                control_def["unit"] = cfg["unit"]
+            if cfg.get("device_class"):
+                control_def["device_class"] = cfg["device_class"]
+            if cfg.get("state_class"):
+                control_def["state_class"] = cfg["state_class"]
+
+            self.discovery_info[entity_title] = control_def
+
+            if sensor_id not in self.sensor_state:
+                self.sensor_state[sensor_id] = {
+                    "last_time": 0,
+                    "last_data": None,
+                }
+
+        return self.discovery_info
+
+    def get_info(self, force_update: bool = False):
+        """Gather information from the system and publish subtopics"""
+        configs = self._get_sensor_configs()
+        cur_time = time.time()
+
+        for sensor_id, cfg in configs.items():
+            if not cfg["command"]:
+                continue
+
+            state = self.sensor_state.setdefault(
+                sensor_id, {"last_time": 0, "last_data": None}
+            )
+            interval = max(1, cfg["interval"])
+
+            if force_update or (cur_time - state["last_time"] >= interval):
+                state["last_time"] = cur_time
+                stdout, stderr, rc = syscommand(
+                    cfg["command"],
+                    ignore_errors=True,
+                    timeout=cfg["timeout"],
+                )
+                if rc == 0:
+                    raw_val = stdout.strip()
+                    payload = self._format_payload(raw_val, cfg["type"])
+                    state["last_data"] = payload
+                    self.lnxlink.run_module(
+                        f"{self.name}/{sensor_id}",
+                        payload,
+                        force_update=force_update,
+                    )
+                else:
+                    logger.warning(
+                        "Custom sensor '%s' command failed (exit code %s): %s",
+                        sensor_id,
+                        rc,
+                        stderr.strip(),
+                    )
+
+        return None
+
+    @staticmethod
+    def _format_payload(raw: str, control_type: str) -> Dict[str, Any]:
+        """Format raw command stdout to structured payload"""
+        # Try JSON first
+        if raw.startswith("{") and raw.endswith("}"):
+            try:
+                data = json.loads(raw)
+                if isinstance(data, dict):
+                    if "value" in data:
+                        return data
+                    return {"value": raw, "attributes": data}
+            except Exception:
+                pass
+
+        if control_type == "binary_sensor":
+            is_on = raw.lower() not in {"false", "no", "0", "off", "", "null"}
+            return {
+                "value": "ON" if is_on else "OFF",
+                "attributes": {"raw": raw},
+            }
+
+        return {
+            "value": raw,
+            "attributes": {"raw": raw},
+        }

--- a/tests/test_custom_sensors.py
+++ b/tests/test_custom_sensors.py
@@ -1,0 +1,83 @@
+"""Tests for the Custom Sensors module."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+from unittest.mock import MagicMock, patch
+
+from lnxlink.modules import custom_sensors
+
+
+class FakeLnxlink:
+    def __init__(self, settings=None):
+        self.config = {"settings": {"custom_sensors": settings or {}}}
+        self.run_module_calls = []
+
+    def add_settings(self, name, default):
+        pass
+
+    def run_module(self, topic, data, force_update=False):
+        self.run_module_calls.append((topic, data, force_update))
+
+
+def test_custom_sensors_exposed_controls_dict():
+    settings = {
+        "gpu_power": {
+            "name": "GPU Power Draw",
+            "command": "echo 45.2",
+            "device_class": "power",
+            "state_class": "measurement",
+            "unit": "W",
+            "icon": "mdi:flash",
+            "interval": 5,
+        }
+    }
+    lnxlink = FakeLnxlink(settings)
+    addon = custom_sensors.Addon(lnxlink)
+    controls = addon.exposed_controls()
+    assert "GPU Power Draw" in controls
+    assert controls["GPU Power Draw"]["type"] == "sensor"
+    assert controls["GPU Power Draw"]["unit"] == "W"
+    assert controls["GPU Power Draw"]["device_class"] == "power"
+    assert controls["GPU Power Draw"]["subtopic"] is True
+
+
+def test_custom_sensors_get_info_runs_command():
+    settings = {
+        "gpu_power": {
+            "name": "GPU Power Draw",
+            "command": "echo 45.2",
+            "interval": 1,
+        }
+    }
+    lnxlink = FakeLnxlink(settings)
+    addon = custom_sensors.Addon(lnxlink)
+    addon.exposed_controls()
+
+    with patch("lnxlink.modules.custom_sensors.syscommand", return_value=("45.2", "", 0)):
+        addon.get_info(force_update=True)
+        assert len(lnxlink.run_module_calls) == 1
+        topic, data, _ = lnxlink.run_module_calls[0]
+        assert topic == "Custom Sensors/gpu_power"
+        assert data["value"] == "45.2"
+
+
+def test_custom_sensors_json_output():
+    settings = {
+        "smart_data": {
+            "name": "Smart Info",
+            "command": "echo '{\"value\": 100, \"health\": \"good\"}'",
+            "interval": 1,
+        }
+    }
+    lnxlink = FakeLnxlink(settings)
+    addon = custom_sensors.Addon(lnxlink)
+    addon.exposed_controls()
+
+    with patch(
+        "lnxlink.modules.custom_sensors.syscommand",
+        return_value=('{"value": 100, "health": "good"}', "", 0),
+    ):
+        addon.get_info(force_update=True)
+        assert len(lnxlink.run_module_calls) == 1
+        _, data, _ = lnxlink.run_module_calls[0]
+        assert data["value"] == 100
+        assert data["health"] == "good"


### PR DESCRIPTION
## Summary
Adds a `custom_sensors` module allowing users to declaratively define custom command sensors with complete Home Assistant Discovery metadata (`device_class`, `state_class`, `unit_of_measurement`, `icon`, `interval`).

Inspired by and ported from the declarative sensor configuration in [Kiot](https://github.com/davidedmundson/kiot) by David Edmundson.

### Features
- Configure arbitrary sensors directly in `config.yaml`.
- Supports `sensor` and `binary_sensor` types.
- Supports `device_class`, `state_class`, and `unit` / `unit_of_measurement`.
- Individual polling interval (`interval` / `every_sec`) and command `timeout`.
- Automatic JSON output parsing: if a command outputs JSON, fields are mapped to attributes and `value`.

## Configuration Example
```yaml
settings:
  custom_sensors:
    gpu_power:
      name: "GPU Power Draw"
      command: "nvidia-smi -q -d POWER | grep 'Instantaneous Power Draw' -m 1 | cut -d':' -f2 | cut -d' ' -f2"
      device_class: "power"
      state_class: "measurement"
      unit: "W"
      icon: "mdi:flash"
      interval: 10
    cpu_power:
      name: "CPU Power Draw"
      command: "bash -c 'F=/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj; E1=$(cat $F); sleep 1; E2=$(cat $F); awk \"BEGIN {print ($E2 - $E1) / 1000000}\"'"
      device_class: "power"
      state_class: "measurement"
      unit: "W"
      interval: 10
```

## Validation
- Tested with dictionary and list configuration formats, string/numeric values, and structured JSON outputs.
- Added unit tests in `tests/test_custom_sensors.py`.
- All pytest tests pass (`uv run --with pytest pytest`).