### PR TITLE
feat(theme_switcher): add desktop dark and light theme switch

### DIFF
--- a/lnxlink/modules/theme_switcher.py
+++ b/lnxlink/modules/theme_switcher.py
@@ -1,0 +1,187 @@
+"""Switch between light and dark desktop themes"""
+import logging
+import os
+import shlex
+from shutil import which
+
+from lnxlink.modules.scripts.helpers import syscommand
+
+logger = logging.getLogger("lnxlink")
+
+
+class Addon:
+    """Addon module for desktop theme switching"""
+
+    def __init__(self, lnxlink):
+        """Setup addon"""
+        self.name = "Theme Switcher"
+        self.lnxlink = lnxlink
+        self.lnxlink.add_settings(
+            "theme_switcher",
+            {
+                "read_command": "",
+                "light_command": "",
+                "dark_command": "",
+                "light_value": "default",
+                "dark_value": "prefer-dark",
+                "light_theme": "BreezeLight",
+                "dark_theme": "BreezeDark",
+            },
+        )
+        self.settings = self.lnxlink.config["settings"].get("theme_switcher", {})
+
+    def exposed_controls(self):
+        """Exposes to home assistant"""
+        return {
+            "Theme": {
+                "type": "switch",
+                "icon": "mdi:theme-light-dark",
+                "value_template": "{{ value_json.status }}",
+                "attributes_template": "{{ value_json.attributes | tojson }}",
+            }
+        }
+
+    def get_info(self):
+        """Gather information from the system"""
+        is_dark, source, raw, theme = self._read_state()
+        status = None
+        if is_dark is True:
+            status = "ON"
+        elif is_dark is False:
+            status = "OFF"
+        return {
+            "status": status,
+            "attributes": {
+                "is_dark": is_dark,
+                "source": source,
+                "raw": raw,
+                "theme": theme,
+            },
+        }
+
+    def start_control(self, topic, data):
+        """Control system"""
+        enabled = self._parse_bool(data)
+        if enabled is None:
+            logger.error("Expected ON/OFF, received: %s", data)
+            return
+        self._set_state(enabled)
+        self.lnxlink.run_module(self.name, self.get_info())
+
+    def _read_state(self):
+        # 1. Custom read command
+        read_command = str(self.settings.get("read_command", "")).strip()
+        if read_command:
+            stdout, _, _ = syscommand(read_command, ignore_errors=True)
+            return self._parse_theme(stdout), "command", stdout, stdout.strip()
+
+        # 2. GNOME gsettings
+        if which("gsettings") is not None:
+            stdout, _, rc = syscommand(
+                "gsettings get org.gnome.desktop.interface color-scheme",
+                ignore_errors=True,
+            )
+            value = self._strip_quotes(stdout)
+            if rc == 0 and value:
+                return (
+                    self._parse_theme(value),
+                    "gnome_gsettings",
+                    stdout,
+                    value,
+                )
+
+        # 3. KDE Plasma kreadconfig
+        for tool in ["kreadconfig6", "kreadconfig5"]:
+            if which(tool) is not None:
+                stdout, _, rc = syscommand(
+                    f"{tool} --file kdeglobals --group General --key ColorScheme",
+                    ignore_errors=True,
+                )
+                if rc == 0 and stdout.strip():
+                    val = stdout.strip()
+                    return self._parse_theme(val), "kde_config", stdout, val
+
+        # 4. Fallback GNOME gtk-theme
+        if which("gsettings") is not None:
+            theme_stdout, _, rc = syscommand(
+                "gsettings get org.gnome.desktop.interface gtk-theme",
+                ignore_errors=True,
+            )
+            theme_value = self._strip_quotes(theme_stdout)
+            if rc == 0 and theme_value:
+                return (
+                    self._parse_theme(theme_value),
+                    "gnome_gtk_theme",
+                    theme_stdout,
+                    theme_value,
+                )
+
+        return None, "none", "", None
+
+    def _set_state(self, is_dark):
+        light_command = str(self.settings.get("light_command", "")).strip()
+        dark_command = str(self.settings.get("dark_command", "")).strip()
+        if is_dark and dark_command:
+            syscommand(dark_command, ignore_errors=True)
+            return
+        if not is_dark and light_command:
+            syscommand(light_command, ignore_errors=True)
+            return
+
+        # 1. GNOME gsettings
+        if which("gsettings") is not None:
+            light_value = self._strip_quotes(self.settings.get("light_value", "default"))
+            dark_value = self._strip_quotes(self.settings.get("dark_value", "prefer-dark"))
+            target_value = dark_value if is_dark else light_value
+            syscommand(
+                f"gsettings set org.gnome.desktop.interface color-scheme {shlex.quote(target_value)}",
+                ignore_errors=True,
+            )
+
+            theme_key = "dark_theme" if is_dark else "light_theme"
+            theme_value = self._strip_quotes(self.settings.get(theme_key, ""))
+            if theme_value:
+                syscommand(
+                    f"gsettings set org.gnome.desktop.interface gtk-theme {shlex.quote(theme_value)}",
+                    ignore_errors=True,
+                )
+
+        # 2. KDE Plasma apply colorscheme
+        if which("plasma-apply-colorscheme") is not None:
+            theme_key = "dark_theme" if is_dark else "light_theme"
+            default_theme = "BreezeDark" if is_dark else "BreezeLight"
+            theme_value = self._strip_quotes(self.settings.get(theme_key, default_theme))
+            syscommand(
+                f"plasma-apply-colorscheme {shlex.quote(theme_value)}",
+                ignore_errors=True,
+            )
+
+    @staticmethod
+    def _parse_bool(value):
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        if text in {"1", "true", "yes", "on", "dark"}:
+            return True
+        if text in {"0", "false", "no", "off", "light"}:
+            return False
+        return None
+
+    @staticmethod
+    def _parse_theme(value):
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        if "dark" in text or text in {"prefer-dark", "dark"}:
+            return True
+        if "light" in text or text in {"default", "light"}:
+            return False
+        return None
+
+    @staticmethod
+    def _strip_quotes(value):
+        if value is None:
+            return ""
+        return str(value).strip().strip("'").strip('"')

--- a/tests/test_theme_switcher.py
+++ b/tests/test_theme_switcher.py
@@ -1,0 +1,64 @@
+"""Tests for the Theme Switcher module."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+from unittest.mock import MagicMock, patch
+
+from lnxlink.modules import theme_switcher
+
+
+class FakeLnxlink:
+    def __init__(self, settings=None):
+        self.config = {"settings": {"theme_switcher": settings or {}}}
+        self.run_module_calls = []
+
+    def add_settings(self, name, default):
+        pass
+
+    def run_module(self, topic, data, force_update=False):
+        self.run_module_calls.append((topic, data, force_update))
+
+
+def test_theme_switcher_exposed_controls():
+    lnxlink = FakeLnxlink()
+    addon = theme_switcher.Addon(lnxlink)
+    controls = addon.exposed_controls()
+    assert "Theme" in controls
+    assert controls["Theme"]["type"] == "switch"
+
+
+def test_theme_switcher_get_info_gnome_dark():
+    lnxlink = FakeLnxlink()
+    addon = theme_switcher.Addon(lnxlink)
+
+    with patch("lnxlink.modules.theme_switcher.which", return_value="/usr/bin/gsettings"), \
+         patch("lnxlink.modules.theme_switcher.syscommand", return_value=("'prefer-dark'", "", 0)):
+        info = addon.get_info()
+        assert info["status"] == "ON"
+        assert info["attributes"]["is_dark"] is True
+        assert info["attributes"]["source"] == "gnome_gsettings"
+
+
+def test_theme_switcher_get_info_kde_light():
+    lnxlink = FakeLnxlink()
+    addon = theme_switcher.Addon(lnxlink)
+
+    def fake_which(cmd):
+        return "/usr/bin/kreadconfig6" if cmd == "kreadconfig6" else None
+
+    with patch("lnxlink.modules.theme_switcher.which", side_effect=fake_which), \
+         patch("lnxlink.modules.theme_switcher.syscommand", return_value=("BreezeLight", "", 0)):
+        info = addon.get_info()
+        assert info["status"] == "OFF"
+        assert info["attributes"]["is_dark"] is False
+        assert info["attributes"]["source"] == "kde_config"
+
+
+def test_theme_switcher_start_control_dark():
+    lnxlink = FakeLnxlink()
+    addon = theme_switcher.Addon(lnxlink)
+
+    with patch("lnxlink.modules.theme_switcher.which", return_value="/usr/bin/gsettings"), \
+         patch("lnxlink.modules.theme_switcher.syscommand", return_value=("", "", 0)) as mock_cmd:
+        addon.start_control(["theme"], "ON")
+        assert mock_cmd.called
+        assert len(lnxlink.run_module_calls) == 1


### PR DESCRIPTION
## Summary
Adds a `theme_switcher` module that exposes a switch entity in Home Assistant to toggle between Light and Dark desktop themes and report the active theme.

### Features
- **GNOME**: Toggles `color-scheme` (`prefer-dark` / `default`) and optional `gtk-theme` via `gsettings`.
- **KDE Plasma**: Reads active colorscheme via `kreadconfig6`/`kreadconfig5` (`kdeglobals`) and applies light/dark colorschemes using `plasma-apply-colorscheme`.
- **Custom commands**: Supports custom `read_command`, `light_command`, `dark_command`.
- **Immediate MQTT feedback**: Publishes updated state immediately on switch toggle.

## Configuration (optional)
```yaml
settings:
  theme_switcher:
    read_command: ""
    light_command: ""
    dark_command: ""
    light_theme: "BreezeLight"
    dark_theme: "BreezeDark"
```

## Validation
- Tested on GNOME and KDE Plasma 6.
- Added unit tests in `tests/test_theme_switcher.py`.
- All pytest tests pass (`uv run --with pytest pytest`).