### PR TITLE
feat(uptime_boot_time): add system uptime and boot time sensors

### DIFF
--- a/lnxlink/modules/uptime_boot_time.py
+++ b/lnxlink/modules/uptime_boot_time.py
@@ -1,0 +1,31 @@
+"""Report system boot time"""
+from datetime import datetime
+
+import psutil
+
+
+class Addon:
+    """Addon module"""
+
+    def __init__(self, lnxlink):
+        """Setup addon"""
+        self.name = "Boot Time"
+        self.lnxlink = lnxlink
+
+    def get_info(self):
+        """Gather information from the system"""
+        boot_time = psutil.boot_time()
+        return {
+            "boot_time": datetime.fromtimestamp(boot_time).astimezone().isoformat(),
+        }
+
+    def exposed_controls(self):
+        """Exposes to home assistant"""
+        return {
+            "Boot Time": {
+                "type": "sensor",
+                "icon": "mdi:clock-start",
+                "device_class": "timestamp",
+                "value_template": "{{ value_json.boot_time }}",
+            },
+        }


### PR DESCRIPTION
## Summary
Adds an `uptime_boot_time` sensor module that reports the system's last boot time (`device_class: timestamp`).

### Features
- Uses `psutil.boot_time()` for cross-platform accuracy.
- **Boot time sensor**: Timestamp sensor with ISO-8601 representation.

## Validation
- Tested on Linux.
- `black`/`ruff`/`pylint` all clean (pylint 10/10).

---
**Update:** addressed review feedback — dropped the `uptime_seconds`/`uptime_human` sensor and attribute (a constantly changing value creates a lot of new entries in the Home Assistant database), keeping only `boot_time`. Removed the test file.
