### PR TITLE
Allow custom shutdown commands

### DIFF
--- a/lnxlink/modules/shutdown.py
+++ b/lnxlink/modules/shutdown.py
@@ -17,10 +17,21 @@ class Addon:
         """Setup addon"""
         self.name = "Shutdown"
         self.lnxlink = lnxlink
+        self.lnxlink.add_settings(
+            "shutdown", {"command": "", "command_timeout": 120}
+        )
 
     def start_control(self, topic, data):
         """Control system"""
         self.lnxlink.temp_connection_callback(True)
+        settings = self.lnxlink.config["settings"]["shutdown"]
+        command = settings["command"]
+        if command:
+            _, _, returncode = syscommand(command, timeout=settings["command_timeout"])
+            if returncode != 0:
+                self.lnxlink.temp_connection_callback(False)
+            return
+
         returncode = None
         try:
             with open_dbus_connection(bus="SYSTEM") as conn:


### PR DESCRIPTION
## Summary

- add a configurable command to the existing shutdown module
- make its timeout configurable, with a 120-second default
- preserve the current D-Bus, `systemctl`, and `shutdown` sequence when no command is configured

## Why

Before an interactive login, all three existing shutdown methods can reach the same polkit authorization denial. This lets an operator explicitly use a command that they have authorized for non-interactive execution, for example:

```yaml
settings:
  shutdown:
    command: "sudo -n /usr/bin/systemctl poweroff"
    command_timeout: 120
```

This does not change system authorization policy; the configured command must already be permitted by the host.

## Validation

- exercised successful and failed configured commands with mocked system calls
- verified an empty command still uses the existing D-Bus path
- ran Ruff, compileall, and `git diff --check`
- completed a clean local Codex review after fixing its timeout finding

Fixes bkbilly/lnxlink#297
