### PR TITLE
Resize large album art before publishing to MQTT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pip --no-cache-dir install \
     flask \
     waitress \
     jeepney \
+    Pillow \
     dbus-mediaplayer \
     dbus-notification \
     dbus-idle \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         gcc \
         python3-dev \
         libjpeg62-turbo-dev \
+        libwebp-dev \
         zlib1g-dev \
         libsystemd-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -53,6 +54,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         dbus \
         libjpeg62-turbo \
+        libwebp7 \
+        libwebpdemux2 \
+        libwebpmux3 \
         zlib1g \
         xdg-utils \
         xdotool \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && \
         cmake \
         gcc \
         python3-dev \
+        libjpeg62-turbo-dev \
+        zlib1g-dev \
         libsystemd-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -50,6 +52,8 @@ WORKDIR /opt/lnxlink
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         dbus \
+        libjpeg62-turbo \
+        zlib1g \
         xdg-utils \
         xdotool \
         x11-xserver-utils && \

--- a/lnxlink/modules/media.py
+++ b/lnxlink/modules/media.py
@@ -93,8 +93,11 @@ class Addon:
         self.dbus_mediaplayer = import_install_package(
             "dbus-mediaplayer", ">=2026.7.0", "dbus_mediaplayer"
         )
-        pillow = import_install_package("Pillow", ">=9.1.0", ("PIL", ["Image"]))
+        pillow = import_install_package(
+            "Pillow", ">=9.1.0", ("PIL", ["Image", "ImageOps"])
+        )
         self.image = pillow.Image
+        self.image_ops = pillow.ImageOps
 
     def exposed_controls(self):
         """Exposes to home assistant"""
@@ -265,14 +268,21 @@ class Addon:
         """Resize and recompress artwork to stay below the MQTT payload limit."""
         with self.image.open(arturl) as source_image:
             source_image.load()
-            source_image = source_image.convert("RGB")
+            source_image = self.image_ops.exif_transpose(source_image)
+            has_transparency = source_image.mode in ("RGBA", "LA") or (
+                source_image.mode == "P" and "transparency" in source_image.info
+            )
+            source_image = source_image.convert("RGBA" if has_transparency else "RGB")
             for max_dimension, quality in THUMBNAIL_PROFILES:
                 image = source_image.copy()
                 image.thumbnail(
                     (max_dimension, max_dimension), self.image.Resampling.LANCZOS
                 )
                 output = BytesIO()
-                image.save(output, format="JPEG", quality=quality, optimize=True)
+                if has_transparency:
+                    image.save(output, format="PNG", optimize=True)
+                else:
+                    image.save(output, format="JPEG", quality=quality, optimize=True)
                 image_data = output.getvalue()
                 if len(image_data) <= MAX_THUMBNAIL_BYTES:
                     logger.debug(

--- a/lnxlink/modules/media.py
+++ b/lnxlink/modules/media.py
@@ -296,7 +296,7 @@ class Addon:
             source_image.load()
             source_image = self.image_ops.exif_transpose(source_image)
             has_transparency = source_image.mode in ("RGBA", "LA") or (
-                source_image.mode == "P" and "transparency" in source_image.info
+                "transparency" in source_image.info
             )
             image = source_image.convert("RGBA" if has_transparency else "RGB")
             for max_dimension, quality in THUMBNAIL_PROFILES:

--- a/lnxlink/modules/media.py
+++ b/lnxlink/modules/media.py
@@ -2,6 +2,7 @@
 import base64
 import hashlib
 import logging
+import os
 import re
 import shlex
 import subprocess
@@ -16,11 +17,14 @@ logger = logging.getLogger("lnxlink")
 
 # Base64 adds about one third, leaving headroom below 128 KiB broker limits.
 MAX_THUMBNAIL_BYTES = 64 * 1024
+MAX_THUMBNAIL_PIXELS = 16 * 1024 * 1024
 THUMBNAIL_PROFILES = (
     (512, 85),
     (384, 80),
     (256, 70),
     (128, 60),
+    (96, 55),
+    (64, 50),
 )
 
 
@@ -35,6 +39,7 @@ class Addon:
         self.players = []
         self._requirements()
         self.prev_info = {}
+        self.thumbnail_cache = (None, b" ")
         self.playmedia_thread = None
         self.process = None
         self.audio_system = self._get_audio_system()
@@ -254,10 +259,23 @@ class Addon:
             try:
                 arturl = player["arturl"].replace("file://", "")
                 with open(arturl, "rb") as image_file:
+                    file_stat = os.fstat(image_file.fileno())
+                    cache_key = (
+                        arturl,
+                        file_stat.st_dev,
+                        file_stat.st_ino,
+                        file_stat.st_size,
+                        file_stat.st_mtime_ns,
+                    )
+                    if self.thumbnail_cache[0] == cache_key:
+                        return self.thumbnail_cache[1]
                     image_data = image_file.read(MAX_THUMBNAIL_BYTES + 1)
                 if len(image_data) <= MAX_THUMBNAIL_BYTES:
-                    return base64.b64encode(image_data)
-                return self._resize_thumbnail(arturl)
+                    thumbnail = base64.b64encode(image_data)
+                else:
+                    thumbnail = self._resize_thumbnail(arturl)
+                self.thumbnail_cache = (cache_key, thumbnail)
+                return thumbnail
             except Exception as err:
                 logger.debug(
                     "Can't create thumbnail: %s, %s", err, traceback.format_exc()
@@ -267,14 +285,21 @@ class Addon:
     def _resize_thumbnail(self, arturl):
         """Resize and recompress artwork to stay below the MQTT payload limit."""
         with self.image.open(arturl) as source_image:
+            if source_image.width * source_image.height > MAX_THUMBNAIL_PIXELS:
+                logger.warning(
+                    "Refusing to decode %dx%d media thumbnail: %s",
+                    source_image.width,
+                    source_image.height,
+                    arturl,
+                )
+                return b" "
             source_image.load()
             source_image = self.image_ops.exif_transpose(source_image)
             has_transparency = source_image.mode in ("RGBA", "LA") or (
                 source_image.mode == "P" and "transparency" in source_image.info
             )
-            source_image = source_image.convert("RGBA" if has_transparency else "RGB")
+            image = source_image.convert("RGBA" if has_transparency else "RGB")
             for max_dimension, quality in THUMBNAIL_PROFILES:
-                image = source_image.copy()
                 image.thumbnail(
                     (max_dimension, max_dimension), self.image.Resampling.LANCZOS
                 )

--- a/lnxlink/modules/media.py
+++ b/lnxlink/modules/media.py
@@ -7,11 +7,21 @@ import shlex
 import subprocess
 import threading
 import traceback
+from io import BytesIO
 from shutil import which
 
 from lnxlink.modules.scripts.helpers import import_install_package, syscommand
 
 logger = logging.getLogger("lnxlink")
+
+# Base64 adds about one third, leaving headroom below 128 KiB broker limits.
+MAX_THUMBNAIL_BYTES = 64 * 1024
+THUMBNAIL_PROFILES = (
+    (512, 85),
+    (384, 80),
+    (256, 70),
+    (128, 60),
+)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -83,6 +93,8 @@ class Addon:
         self.dbus_mediaplayer = import_install_package(
             "dbus-mediaplayer", ">=2026.7.0", "dbus_mediaplayer"
         )
+        pillow = import_install_package("Pillow", ">=9.1.0", ("PIL", ["Image"]))
+        self.image = pillow.Image
 
     def exposed_controls(self):
         """Exposes to home assistant"""
@@ -239,12 +251,43 @@ class Addon:
             try:
                 arturl = player["arturl"].replace("file://", "")
                 with open(arturl, "rb") as image_file:
-                    image_thumbnail = base64.b64encode(image_file.read())
-                    return image_thumbnail
+                    image_data = image_file.read(MAX_THUMBNAIL_BYTES + 1)
+                if len(image_data) <= MAX_THUMBNAIL_BYTES:
+                    return base64.b64encode(image_data)
+                return self._resize_thumbnail(arturl)
             except Exception as err:
                 logger.debug(
                     "Can't create thumbnail: %s, %s", err, traceback.format_exc()
                 )
+        return b" "
+
+    def _resize_thumbnail(self, arturl):
+        """Resize and recompress artwork to stay below the MQTT payload limit."""
+        with self.image.open(arturl) as source_image:
+            source_image.load()
+            source_image = source_image.convert("RGB")
+            for max_dimension, quality in THUMBNAIL_PROFILES:
+                image = source_image.copy()
+                image.thumbnail(
+                    (max_dimension, max_dimension), self.image.Resampling.LANCZOS
+                )
+                output = BytesIO()
+                image.save(output, format="JPEG", quality=quality, optimize=True)
+                image_data = output.getvalue()
+                if len(image_data) <= MAX_THUMBNAIL_BYTES:
+                    logger.debug(
+                        "Resized media thumbnail to %dx%d and %d bytes: %s",
+                        image.width,
+                        image.height,
+                        len(image_data),
+                        arturl,
+                    )
+                    return base64.b64encode(image_data)
+        logger.warning(
+            "Can't resize media thumbnail below %d bytes: %s",
+            MAX_THUMBNAIL_BYTES,
+            arturl,
+        )
         return b" "
 
     def stop_playmedia(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ psutil>=7.0.0
 requests>=2.31.0
 
 # Modules dependencies
+Pillow>=9.1.0
 PyGObject>=3.44.0
 SpeechRecognition>=3.10.0
 dbus-idle>=2026.8.0


### PR DESCRIPTION
## Summary

- preserve artwork up to 64 KiB byte-for-byte and cache the result by file identity
- apply EXIF orientation before resizing oversized artwork
- resize opaque artwork as JPEG and transparent artwork as optimized PNG until it fits the safe payload size
- reject excessive decoded dimensions before loading image pixels
- install Pillow and its JPEG/zlib/WebP dependencies in all Docker targets, including arm/v7

## Why

Base64 expands artwork by about one third. A large local cover can therefore
exceed a broker's MQTT packet limit, disconnect the entire LNXlink client, and
leave every entity unavailable while the client repeatedly reconnects.

The 64 KiB image limit keeps the encoded payload below 128 KiB with room for
the MQTT topic and framing. Oversized artwork is tried at progressively smaller
dimensions and JPEG quality. EXIF orientation is applied before metadata is
discarded, and alpha-bearing artwork stays in an alpha-capable PNG instead of
gaining a black background. A decoded-pixel bound prevents compressed image
bombs, while the file-identity cache avoids recompressing unchanged artwork on
position or volume updates.

## Validation

- `uvx pre-commit run --all-files`
- synthetic oversized EXIF-orientated JPEG retained the displayed orientation
- high-entropy 128 x 128 RGBA artwork fell back below 128 px, retained alpha, and fit below 64 KiB
- oversized RGB and grayscale PNGs retained their `tRNS` color-key transparency
- repeated requests for an unchanged file reused the cached encoded thumbnail
- a synthetic 12000 x 12000 image was rejected before pixel decoding
- full native amd64 Docker build completed and imported `PIL.Image` and `PIL.ImageOps`
- full `linux/arm/v7` image build completed, including Pillow's source wheel build and a successful WebP encode/decode check in the resulting container
